### PR TITLE
Feature/post-selection

### DIFF
--- a/.github/workflows/docs/conf.py
+++ b/.github/workflows/docs/conf.py
@@ -118,7 +118,6 @@ def correct_signature(
     signature: str,
     return_annotation: str,
 ) -> (str, str):
-
     new_signature = signature
     new_return_annotation = return_annotation
     for k, v in app.config.custom_internal_mapping.items():

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,4 +2,4 @@ API documentation
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: pytket.extensions.cutensornet
-    :members: TensorNetwork, PauliOperatorTensorNetwork, ExpectationValueTensorNetwork, tk_to_tensor_network, CuTensorNetBackend
+    :members: TensorNetwork, PauliOperatorTensorNetwork, ExpectationValueTensorNetwork, measure_qubits_state, tk_to_tensor_network, CuTensorNetBackend

--- a/mypy.ini
+++ b/mypy.ini
@@ -26,7 +26,3 @@ ignore_errors = True
 [mypy-lark.*]
 ignore_missing_imports = True
 ignore_errors = True
-
-[mypy-pytket]
-ignore_missing_imports = True
-ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -26,3 +26,7 @@ ignore_errors = True
 [mypy-lark.*]
 ignore_missing_imports = True
 ignore_errors = True
+
+[mypy-pytket]
+ignore_missing_imports = True
+ignore_errors = True

--- a/pytket/extensions/cutensornet/__init__.py
+++ b/pytket/extensions/cutensornet/__init__.py
@@ -23,4 +23,7 @@ from .tensor_network_convert import (
     PauliOperatorTensorNetwork,
     ExpectationValueTensorNetwork,
     tk_to_tensor_network,
+    measure_qubits_state,
 )
+
+from .utils import circuit_statevector_postselect

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -49,7 +49,6 @@ from pytket.passes import (  # type: ignore
 from pytket.utils.operators import QubitPauliOperator
 
 
-
 # TODO: this is temporary - probably don't need it eventually?
 def _sq(a: Expr, b: Expr, c: Expr) -> Circuit:
     circ = Circuit(1)
@@ -299,14 +298,14 @@ class CuTensorNetBackend(Backend):
         post_selection: dict[Qubit, int],
         valid_check: bool = True,
     ) -> float:
-        """Calculates expectation value of an operator using 
+        """Calculates expectation value of an operator using
         cuTensorNet contraction where the is a post selection on an ancilla register.
 
         Args:
             state_circuit: Circuit representing state.
             operator: Operator which expectation value is to be calculated.
             valid_check: Whether to perform circuit validity check.
-            post_selection: Dictionary of qubits to post select where the key is 
+            post_selection: Dictionary of qubits to post select where the key is
                 qubit and the value is bit outcome.
 
         Returns:
@@ -321,7 +320,6 @@ class CuTensorNetBackend(Backend):
                 "Post selection qubit must not be a not be a subset of operator qubits"
             )
 
-        
         ket_network = TensorNetwork(state_circuit)
         bra_network = ket_network.dagger()
         ket_network = measure_qubits_state(ket_network, post_selection)
@@ -332,7 +330,6 @@ class CuTensorNetBackend(Backend):
         expectation = 0
 
         for qos, coeff in operator._dict.items():
-
             expectation_value_network = ExpectationValueTensorNetwork(
                 bra_network, qos, ket_network
             )

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -280,7 +280,6 @@ class CuTensorNetBackend(Backend):
             expectation_term = numeric_coeff * cq.contract(
                 *expectation_value_network.cuquantum_interleaved
             )
-            print(expectation_term)
             expectation += expectation_term
         return expectation.real
 

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -233,7 +233,7 @@ class CuTensorNetBackend(Backend):
         self,
         state_circuit: Circuit,
         operator: QubitPauliOperator,
-        post_selection: Optional[Union[None, dict[Qubit, int]]] = None,
+        post_selection: Optional[dict[Qubit, int]] = None,
         valid_check: bool = True,
     ) -> float:
         """Calculates expectation value of an operator using cuTensorNet contraction.

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -299,7 +299,7 @@ class CuTensorNetBackend(Backend):
         valid_check: bool = True,
     ) -> float:
         """Calculates expectation value of an operator using
-        cuTensorNet contraction where the is a post selection on an ancilla register.
+        cuTensorNet contraction where there is a post selection on an ancilla register.
 
         Args:
             state_circuit: Circuit representing state.
@@ -317,7 +317,7 @@ class CuTensorNetBackend(Backend):
         post_select_qubits = list(post_selection.keys())
         if set(post_select_qubits).issubset(operator.all_qubits):
             raise ValueError(
-                "Post selection qubit must not be a not be a subset of operator qubits"
+                "Post selection qubit must not be a subset of operator qubits"
             )
 
         ket_network = TensorNetwork(state_circuit)

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -25,7 +25,7 @@ from typing import List, Union, Optional, Sequence
 from uuid import uuid4
 import numpy as np
 from sympy import Expr  # type: ignore
-from pytket.circuit import Circuit, OpType  # type: ignore
+from pytket.circuit import Circuit, OpType, Qubit  # type: ignore
 from pytket.backends import ResultHandle, CircuitStatus, StatusEnum, CircuitNotRunError
 from pytket.backends.backend import KwargTypes, Backend, BackendResult
 from pytket.backends.backendinfo import BackendInfo
@@ -34,6 +34,7 @@ from pytket.extensions.cutensornet.tensor_network_convert import (
     TensorNetwork,
     ExpectationValueTensorNetwork,
     tk_to_tensor_network,
+    measure_qubits_state,
 )
 from pytket.predicates import Predicate, GateSetPredicate, NoClassicalBitsPredicate  # type: ignore
 from pytket.passes import (  # type: ignore
@@ -46,6 +47,7 @@ from pytket.passes import (  # type: ignore
     SquashCustom,
 )
 from pytket.utils.operators import QubitPauliOperator
+
 
 
 # TODO: this is temporary - probably don't need it eventually?
@@ -289,3 +291,57 @@ class CuTensorNetBackend(Backend):
         overlap_net_interleaved = ket_net.vdot(TensorNetwork(circuit_bra))
         overlap: float = cq.contract(*overlap_net_interleaved)
         return overlap
+
+    def get_operator_expectation_value_postselect(
+        self,
+        state_circuit: Circuit,
+        operator: QubitPauliOperator,
+        post_selection: dict[Qubit, int],
+        valid_check: bool = True,
+    ) -> float:
+        """Calculates expectation value of an operator using 
+        cuTensorNet contraction where the is a post selection on an ancilla register.
+
+        Args:
+            state_circuit: Circuit representing state.
+            operator: Operator which expectation value is to be calculated.
+            valid_check: Whether to perform circuit validity check.
+            post_selection: Dictionary of qubits to post select where the key is 
+                qubit and the value is bit outcome.
+
+        Returns:
+            Expectation value.
+        """
+        if valid_check:
+            self._check_all_circuits([state_circuit])
+
+        post_select_qubits = list(post_selection.keys())
+        if set(post_select_qubits).issubset(operator.all_qubits):
+            raise ValueError(
+                "Post selection qubit must not be a not be a subset of operator qubits"
+            )
+
+        
+        ket_network = TensorNetwork(state_circuit)
+        bra_network = ket_network.dagger()
+        ket_network = measure_qubits_state(ket_network, post_selection)
+        bra_network = measure_qubits_state(
+            bra_network, post_selection
+        )  # This needed because dagger does not work with post selection
+
+        expectation = 0
+
+        for qos, coeff in operator._dict.items():
+
+            expectation_value_network = ExpectationValueTensorNetwork(
+                bra_network, qos, ket_network
+            )
+            if isinstance(coeff, Expr):
+                numeric_coeff = complex(coeff.evalf())  # type: ignore
+            else:
+                numeric_coeff = complex(coeff)
+            expectation_term = numeric_coeff * cq.contract(
+                *expectation_value_network.cuquantum_interleaved
+            )
+            expectation += expectation_term
+        return expectation.real

--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -542,6 +542,8 @@ def measure_qubits_state(
 
 
 class PauliOperatorTensorNetwork:
+    """Handles a tensor network representing a Pauli operator string."""
+
     PAULI = {
         "X": np.array([[0, 1], [1, 0]], dtype="complex128"),
         "Y": np.array([[0, -1j], [1j, 0]], dtype="complex128"),
@@ -604,6 +606,7 @@ class PauliOperatorTensorNetwork:
 
     @property
     def cuquantum_interleaved(self) -> list:
+        """Returns an interleaved format of the circuit tensor network."""
         return self._cuquantum_interleaved
 
 

--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -530,8 +530,8 @@ def measure_qubits_state(
 
     Args:
         ket: a TensorNetwork object representing a quantum state.
-        measurement_dict: a dictionary of qubit ids and their
-        corresponding bit values to be assigned to the measured qubits.
+        measurement_dict: a dictionary of qubit ids and their corresponding bit values
+         to be assigned to the measured qubits.
         loglevel: logging level.
 
     Returns:

--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -25,7 +25,7 @@ from numpy.typing import NDArray
 from pytket import Qubit  # type: ignore
 from pytket.utils import Graph
 from pytket.pauli import QubitPauliString  # type: ignore
-from pytket.circuit import Circuit, Qubit
+from pytket.circuit import Circuit, Qubit  # type: ignore
 from pytket.utils import permute_rows_cols_in_unitary
 
 
@@ -484,8 +484,8 @@ class TensorNetwork:
 
 
 def _measure_qubit_state(
-    ket: TensorNetwork, qubit_id: Qubit, bit_value: int, loglevel=logging.INFO
-):
+    ket: TensorNetwork, qubit_id: Qubit, bit_value: int, loglevel: int = logging.INFO
+) -> TensorNetwork:
     """Measures a qubit in a tensor network. by appending a measurement
     gate to the tensor network.
     The measurment gate is applied via appending a tensor cap of
@@ -516,8 +516,8 @@ def _measure_qubit_state(
 
 # TODO: Make this compatible with mid circuit measurements and reset
 def measure_qubits_state(
-    ket: TensorNetwork, measurement_dict: dict[Qubit, int], loglevel=logging.INFO
-):
+    ket: TensorNetwork, measurement_dict: dict[Qubit, int], loglevel: int = logging.INFO
+) -> TensorNetwork:
     """Measures a list of qubits in a tensor network. by appending a
     measurement gate to the tensor network.
     The measurment gate is applied via appending a tensor cap
@@ -603,7 +603,7 @@ class PauliOperatorTensorNetwork:
         self._logger.debug(f"Pauli TN: {self.cuquantum_interleaved}")
 
     @property
-    def cuquantum_interleaved(self):
+    def cuquantum_interleaved(self) -> list:
         return self._cuquantum_interleaved
 
 

--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -486,9 +486,9 @@ class TensorNetwork:
 def _measure_qubit_state(
     ket: TensorNetwork, qubit_id: Qubit, bit_value: int, loglevel=logging.INFO
 ):
-    """Measures a qubit in a tensor network. by appending a measurement 
+    """Measures a qubit in a tensor network. by appending a measurement
     gate to the tensor network.
-    The measurment gate is applied via appending a tensor cap of 
+    The measurment gate is applied via appending a tensor cap of
     the form:  0: [1, 0] or 1: [0, 1] to the interleaved einsum input.
     Therefor removing one of the open indices of the tensor network.
 
@@ -499,8 +499,8 @@ def _measure_qubit_state(
         loglevel: logging level.
 
     Returns:
-        A TensorNetwork object representing a quantum state after the 
-        measurement with a modified interleaved notation containing the extra 
+        A TensorNetwork object representing a quantum state after the
+        measurement with a modified interleaved notation containing the extra
         measurement tensor.
     """
 
@@ -518,21 +518,21 @@ def _measure_qubit_state(
 def measure_qubits_state(
     ket: TensorNetwork, measurement_dict: dict[Qubit, int], loglevel=logging.INFO
 ):
-    """Measures a list of qubits in a tensor network. by appending a 
+    """Measures a list of qubits in a tensor network. by appending a
     measurement gate to the tensor network.
-    The measurment gate is applied via appending a tensor cap 
+    The measurment gate is applied via appending a tensor cap
     of the form:  0: [1, 0] or 1: [0, 1] to the interleaved einsum input.
     Therefor removing the open indices of the tensor network corresponding
       to the measured qubits.
 
     Args:
         ket: a TensorNetwork object representing a quantum state.
-        measurement_dict: a dictionary of qubit ids and their 
+        measurement_dict: a dictionary of qubit ids and their
         corresponding bit values to be assigned to the measured qubits.
         loglevel: logging level.
 
     Returns:
-        A TensorNetwork object representing a quantum state after 
+        A TensorNetwork object representing a quantum state after
         the measurement with a modified interleaved notation containing
         the extra measurement tensors.
     """

--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -115,8 +115,8 @@ class TensorNetwork:
 
         Note:
            The returned map values are lists and may contain more than one
-            representation - for >1-qubit gates, different topologies (e.g. upward and
-            downward) are taken into account.
+           representation - for >1-qubit gates, different topologies (e.g. upward and
+           downward) are taken into account.
         """
         name_set = {com.op.get_name() for com in self._circuit.get_commands()}
         gate_tensors = defaultdict(list)
@@ -185,7 +185,7 @@ class TensorNetwork:
 
         Returns:
             List of tensors representing circuit gates (tensor network nodes) in the
-             reversed order of circuit graph nodes.
+            reversed order of circuit graph nodes.
         """
         self._gate_tensors = self._get_gate_tensors(adj=adj)
         node_tensors = []
@@ -261,8 +261,8 @@ class TensorNetwork:
 
         Returns:
             A list of lists of tensor network nodes edges (tensors dimensions) indices
-             and a list of outward ("sticky") indices along which there will be no
-             contraction.
+            and a list of outward ("sticky") indices along which there will be no
+            contraction.
         """
         sign = -1 if adj else 1
         self._logger.debug(f"Network nodes: \n{net.nodes(data=True)}")
@@ -424,7 +424,7 @@ class TensorNetwork:
 
         Returns:
             A list of interleaved tensors (ndarrays) and lists of corresponding edges
-             indices.
+            indices.
         """
         tn_interleaved = []
         for tensor, indices in zip(self._node_tensors, self._node_tensor_indices):
@@ -438,7 +438,7 @@ class TensorNetwork:
 
         Returns:
             A new TensorNetwork object, containing an adjoint representation of the
-             input object.
+            input object.
         """
         tn_dagger = TensorNetwork(self._circuit.copy(), adj=True)
         self._logger.debug(
@@ -460,7 +460,7 @@ class TensorNetwork:
 
         Returns:
             A tensor network in an interleaved form, representing an overlap of two
-             circuits.
+            circuits.
         """
         if set(self.sticky_indices.keys()) != set(tn_other.sticky_indices.keys()):
             raise RuntimeError("The two tensor networks are incompatible!")
@@ -486,8 +486,9 @@ class TensorNetwork:
 def measure_qubit_state(
     ket: TensorNetwork, qubit_id: Qubit, bit_value: int, loglevel: int = logging.INFO
 ) -> TensorNetwork:
-    """Measures a qubit in a tensor network. by appending a measurement
-    gate to the tensor network.
+    """Measures a qubit in a tensor network.
+
+    Does so by appending a measurement gate to the tensor network.
     The measurment gate is applied via appending a tensor cap of
     the form:  0: [1, 0] or 1: [0, 1] to the interleaved einsum input.
     Therefor removing one of the open indices of the tensor network.
@@ -519,12 +520,13 @@ def measure_qubit_state(
 def measure_qubits_state(
     ket: TensorNetwork, measurement_dict: dict[Qubit, int], loglevel: int = logging.INFO
 ) -> TensorNetwork:
-    """Measures a list of qubits in a tensor network. by appending a
-    measurement gate to the tensor network.
+    """Measures a list of qubits in a tensor network.
+
+    Does so by appending a measurement gate to the tensor network.
     The measurment gate is applied via appending a tensor cap
     of the form:  0: [1, 0] or 1: [0, 1] to the interleaved einsum input.
     Therefor removing the open indices of the tensor network corresponding
-      to the measured qubits.
+    to the measured qubits.
 
     Args:
         ket: a TensorNetwork object representing a quantum state.
@@ -647,7 +649,7 @@ class ExpectationValueTensorNetwork:
 
         Returns:
             A tensor network representing expectation value in the interleaved format
-             (list).
+            (list).
         """
         tn_concatenated = self._bra.cuquantum_interleaved
         tn_concatenated.extend(self._operator.cuquantum_interleaved)
@@ -663,6 +665,6 @@ def tk_to_tensor_network(tkc: Circuit) -> List[Union[NDArray, List]]:
 
     Returns:
         A tensor network representing the input circuit in the interleaved format
-         (list).
+        (list).
     """
     return TensorNetwork(tkc).cuquantum_interleaved

--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -651,7 +651,7 @@ class ExpectationValueTensorNetwork:
             A tensor network representing expectation value in the interleaved format
             (list).
         """
-        tn_concatenated = self._bra.cuquantum_interleaved
+        tn_concatenated = self._bra.cuquantum_interleaved.copy()
         tn_concatenated.extend(self._operator.cuquantum_interleaved)
         tn_concatenated.extend(self._ket.cuquantum_interleaved)
         return tn_concatenated

--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -483,7 +483,7 @@ class TensorNetwork:
         return tn_concatenated
 
 
-def _measure_qubit_state(
+def measure_qubit_state(
     ket: TensorNetwork, qubit_id: Qubit, bit_value: int, loglevel: int = logging.INFO
 ) -> TensorNetwork:
     """Measures a qubit in a tensor network. by appending a measurement
@@ -511,6 +511,7 @@ def _measure_qubit_state(
 
     sticky_ind = ket.sticky_indices[qubit_id]
     ket._cuquantum_interleaved.extend([cap[bit_value], [sticky_ind]])
+    ket.sticky_indices.pop(qubit_id)
     return ket
 
 
@@ -537,7 +538,7 @@ def measure_qubits_state(
         the extra measurement tensors.
     """
     for qubit_id, bit_value in measurement_dict.items():
-        ket = _measure_qubit_state(ket, qubit_id, bit_value, loglevel)
+        ket = measure_qubit_state(ket, qubit_id, bit_value, loglevel)
     return ket
 
 

--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -25,7 +25,7 @@ from numpy.typing import NDArray
 from pytket import Qubit  # type: ignore
 from pytket.utils import Graph
 from pytket.pauli import QubitPauliString  # type: ignore
-from pytket.circuit import Circuit
+from pytket.circuit import Circuit, Qubit
 from pytket.utils import permute_rows_cols_in_unitary
 
 
@@ -483,9 +483,65 @@ class TensorNetwork:
         return tn_concatenated
 
 
-class PauliOperatorTensorNetwork:
-    """Handles a tensor network representing a Pauli operator string."""
+def _measure_qubit_state(
+    ket: TensorNetwork, qubit_id: Qubit, bit_value: int, loglevel=logging.INFO
+):
+    """Measures a qubit in a tensor network. by appending a measurement 
+    gate to the tensor network.
+    The measurment gate is applied via appending a tensor cap of 
+    the form:  0: [1, 0] or 1: [0, 1] to the interleaved einsum input.
+    Therefor removing one of the open indices of the tensor network.
 
+    Args:
+        ket: a TensorNetwork object representing a quantum state.
+        qubit_id: a qubit id.
+        bit_value: a bit value to be assigned to the measured qubit.
+        loglevel: logging level.
+
+    Returns:
+        A TensorNetwork object representing a quantum state after the 
+        measurement with a modified interleaved notation containing the extra 
+        measurement tensor.
+    """
+
+    cap = {
+        0: np.array([1, 0], dtype="complex128"),
+        1: np.array([0, 1], dtype="complex128"),
+    }
+
+    sticky_ind = ket.sticky_indices[qubit_id]
+    ket._cuquantum_interleaved.extend([cap[bit_value], [sticky_ind]])
+    return ket
+
+
+# TODO: Make this compatible with mid circuit measurements and reset
+def measure_qubits_state(
+    ket: TensorNetwork, measurement_dict: dict[Qubit, int], loglevel=logging.INFO
+):
+    """Measures a list of qubits in a tensor network. by appending a 
+    measurement gate to the tensor network.
+    The measurment gate is applied via appending a tensor cap 
+    of the form:  0: [1, 0] or 1: [0, 1] to the interleaved einsum input.
+    Therefor removing the open indices of the tensor network corresponding
+      to the measured qubits.
+
+    Args:
+        ket: a TensorNetwork object representing a quantum state.
+        measurement_dict: a dictionary of qubit ids and their 
+        corresponding bit values to be assigned to the measured qubits.
+        loglevel: logging level.
+
+    Returns:
+        A TensorNetwork object representing a quantum state after 
+        the measurement with a modified interleaved notation containing
+        the extra measurement tensors.
+    """
+    for qubit_id, bit_value in measurement_dict.items():
+        ket = _measure_qubit_state(ket, qubit_id, bit_value, loglevel)
+    return ket
+
+
+class PauliOperatorTensorNetwork:
     PAULI = {
         "X": np.array([[0, 1], [1, 0]], dtype="complex128"),
         "Y": np.array([[0, -1j], [1j, 0]], dtype="complex128"),
@@ -547,8 +603,7 @@ class PauliOperatorTensorNetwork:
         self._logger.debug(f"Pauli TN: {self.cuquantum_interleaved}")
 
     @property
-    def cuquantum_interleaved(self) -> list:
-        """Returns an interleaved format of the circuit tensor network."""
+    def cuquantum_interleaved(self):
         return self._cuquantum_interleaved
 
 

--- a/pytket/extensions/cutensornet/utils.py
+++ b/pytket/extensions/cutensornet/utils.py
@@ -11,19 +11,18 @@ def _reorder_qlist(post_select_dict: dict, qlist: list[Qubit]):
         qlist (list): List of qubits
 
     Returns:
-        tuple: Tuple containing: q_list_reordered (list): List of qubits 
+        tuple: Tuple containing: q_list_reordered (list): List of qubits
         reordered so that post_select_qubit is first in
         the list. q (Qubit): The post select qubit
     """
 
     post_select_q = list(post_select_dict.keys())[0]
-        
+
     pop_i = qlist.index(post_select_q)
 
     q = qlist.pop(pop_i)
 
     q_list_reordered = [q]
-
     q_list_reordered.extend(qlist)
 
     return q_list_reordered, q
@@ -32,9 +31,9 @@ def _reorder_qlist(post_select_dict: dict, qlist: list[Qubit]):
 def statevector_postselect(
     qlist: list[Qubit], sv: NDArray, post_select_dict: dict[Qubit, int]
 ):
-    """Post selects a statevector. recursively calls itself if there 
-    are multiple post select qubits. Uses backend result to get statevector 
-    and permutes so the the post select qubit for each 
+    """Post selects a statevector. recursively calls itself if there
+    are multiple post select qubits. Uses backend result to get statevector
+    and permutes so the the post select qubit for each
     iteration is first in the list.
 
     Args:
@@ -72,8 +71,8 @@ def statevector_postselect(
 
 
 def circuit_statevector_postselect(circ: Circuit, post_select_dict: dict[Qubit, int]):
-    """Post selects a circuit statevector. recursively calls 
-    itself if there are multiple post select qubits. Should only be 
+    """Post selects a circuit statevector. recursively calls
+    itself if there are multiple post select qubits. Should only be
     used for testing small circuits as it uses the circuit.get_unitary() method.
 
     Args:

--- a/pytket/extensions/cutensornet/utils.py
+++ b/pytket/extensions/cutensornet/utils.py
@@ -13,9 +13,8 @@ def _reorder_qlist(
         qlist (list): List of qubits
 
     Returns:
-        tuple: Tuple containing: q_list_reordered (list): List of qubits
-        reordered so that post_select_qubit is first in
-        the list. q (Qubit): The post select qubit
+        Tuple containing a list of qubits reordered so that `post_select_qubit` is first
+        in the list, and the post select qubit.
     """
 
     post_select_q = list(post_select_dict.keys())[0]
@@ -33,18 +32,19 @@ def _reorder_qlist(
 def statevector_postselect(
     qlist: list[Qubit], sv: NDArray, post_select_dict: dict[Qubit, int]
 ) -> NDArray:
-    """Post selects a statevector. recursively calls itself if there
-    are multiple post select qubits. Uses backend result to get statevector
-    and permutes so the the post select qubit for each
-    iteration is first in the list.
+    """Post selects a statevector.
+
+    Recursively calls itself if there are multiple post select qubits.
+    Uses backend result to get statevecto and permutes so the the post select qubit for
+    each iteration is first in the list.
 
     Args:
-        qlist (list): List of qubits
-        sv (npt.NDArray): Statevector
-        post_select_dict (dict): Dictionary of post selection qubit and value
+        qlist: List of qubits.
+        sv: Statevector.
+        post_select_dict: Dictionary of post selection qubit and value.
 
     Returns:
-        npt.NDArray: Post selected statevector
+        Post selected statevector.
     """
 
     n = len(qlist)
@@ -80,11 +80,11 @@ def circuit_statevector_postselect(
     used for testing small circuits as it uses the circuit.get_unitary() method.
 
     Args:
-        circ (Circuit): Circuit
-        post_select_dict (dict): Dictionary of post selection qubit and value
+        circ: Circuit.
+        post_select_dict: Dictionary of post selection qubit and value.
 
     Returns:
-        npt.NDArray: Post selected statevector
+        Post selected statevector.
     """
 
     return statevector_postselect(

--- a/pytket/extensions/cutensornet/utils.py
+++ b/pytket/extensions/cutensornet/utils.py
@@ -1,9 +1,11 @@
 from numpy.typing import NDArray
 from pytket.backends.backendresult import BackendResult
-from pytket.circuit import Qubit, Circuit
+from pytket.circuit import Qubit, Circuit  # type: ignore
 
 
-def _reorder_qlist(post_select_dict: dict, qlist: list[Qubit]):
+def _reorder_qlist(
+    post_select_dict: dict, qlist: list[Qubit]
+) -> tuple[list[Qubit], Qubit]:
     """Reorder qlist so that post_select_qubit is first in the list.
 
     Args:
@@ -30,7 +32,7 @@ def _reorder_qlist(post_select_dict: dict, qlist: list[Qubit]):
 
 def statevector_postselect(
     qlist: list[Qubit], sv: NDArray, post_select_dict: dict[Qubit, int]
-):
+) -> NDArray:
     """Post selects a statevector. recursively calls itself if there
     are multiple post select qubits. Uses backend result to get statevector
     and permutes so the the post select qubit for each
@@ -70,7 +72,9 @@ def statevector_postselect(
     return statevector_postselect(q_list_reordered, new_sv, post_select_dict)
 
 
-def circuit_statevector_postselect(circ: Circuit, post_select_dict: dict[Qubit, int]):
+def circuit_statevector_postselect(
+    circ: Circuit, post_select_dict: dict[Qubit, int]
+) -> NDArray:
     """Post selects a circuit statevector. recursively calls
     itself if there are multiple post select qubits. Should only be
     used for testing small circuits as it uses the circuit.get_unitary() method.

--- a/pytket/extensions/cutensornet/utils.py
+++ b/pytket/extensions/cutensornet/utils.py
@@ -1,0 +1,89 @@
+from numpy.typing import NDArray
+from pytket.backends.backendresult import BackendResult
+from pytket.circuit import Qubit, Circuit
+
+
+def _reorder_qlist(post_select_dict: dict, qlist: list[Qubit]):
+    """Reorder qlist so that post_select_qubit is first in the list.
+
+    Args:
+        post_select_dict (dict): Dictionary of post selection qubit and value
+        qlist (list): List of qubits
+
+    Returns:
+        tuple: Tuple containing: q_list_reordered (list): List of qubits 
+        reordered so that post_select_qubit is first in
+        the list. q (Qubit): The post select qubit
+    """
+
+    post_select_q = list(post_select_dict.keys())[0]
+        
+    pop_i = qlist.index(post_select_q)
+
+    q = qlist.pop(pop_i)
+
+    q_list_reordered = [q]
+
+    q_list_reordered.extend(qlist)
+
+    return q_list_reordered, q
+
+
+def statevector_postselect(
+    qlist: list[Qubit], sv: NDArray, post_select_dict: dict[Qubit, int]
+):
+    """Post selects a statevector. recursively calls itself if there 
+    are multiple post select qubits. Uses backend result to get statevector 
+    and permutes so the the post select qubit for each 
+    iteration is first in the list.
+
+    Args:
+        qlist (list): List of qubits
+        sv (npt.NDArray): Statevector
+        post_select_dict (dict): Dictionary of post selection qubit and value
+
+    Returns:
+        npt.NDArray: Post selected statevector
+    """
+
+    n = len(qlist)
+    n_p = len(post_select_dict)
+
+    b_res = BackendResult(state=sv, q_bits=qlist)
+
+    q_list_reordered, q = _reorder_qlist(post_select_dict, qlist)
+
+    sv = b_res.get_state(qbits=q_list_reordered)
+
+    if post_select_dict[q] == 0:
+        new_sv = sv[: 2 ** (n - 1) :]
+    elif post_select_dict[q] == 1:
+        new_sv = sv[2 ** (n - 1) :]
+    else:
+        raise ValueError("post_select_dict[q] must be 0 or 1")
+
+    if n_p == 1:
+        return new_sv
+
+    post_select_dict.pop(q)
+    q_list_reordered.pop(0)
+
+    return statevector_postselect(q_list_reordered, new_sv, post_select_dict)
+
+
+def circuit_statevector_postselect(circ: Circuit, post_select_dict: dict[Qubit, int]):
+    """Post selects a circuit statevector. recursively calls 
+    itself if there are multiple post select qubits. Should only be 
+    used for testing small circuits as it uses the circuit.get_unitary() method.
+
+    Args:
+        circ (Circuit): Circuit
+        post_select_dict (dict): Dictionary of post selection qubit and value
+
+    Returns:
+        npt.NDArray: Post selected statevector
+    """
+
+    return statevector_postselect(
+        circ.qubits, circ.get_statevector(), post_select_dict
+    )  # TODO this does not account for global phase if just taking circuit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from pytket.circuit import Circuit, OpType
+from pytket.circuit import Circuit, OpType  # type: ignore
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from pytket.circuit import Circuit
+from pytket.circuit import Circuit, OpType
 
 
 @pytest.fixture
@@ -59,6 +59,27 @@ def q2_hadamard_test() -> Circuit:
 
 
 @pytest.fixture
+def q2_lcu1() -> Circuit:
+    circuit = Circuit(2)
+    circuit.Ry(0.78, 1).Ry(0.27, 0).CX(0, 1).CZ(0, 1).Ry(-0.27, 0)
+    return circuit
+
+
+@pytest.fixture
+def q2_lcu2() -> Circuit:
+    circuit = Circuit(2)
+    circuit.Ry(0.78, 1).Ry(0.27, 0).CZ(0, 1).CY(0, 1).Ry(-0.27, 0)
+    return circuit
+
+
+@pytest.fixture
+def q2_lcu3() -> Circuit:
+    circuit = Circuit(2)
+    circuit.Ry(0.78, 1).Rx(0.67, 0).CX(0, 1).CZ(0, 1).Ry(-0.67, 0)
+    return circuit
+
+
+@pytest.fixture
 def q3_v0cx02() -> Circuit:
     circuit = Circuit(3)
     circuit.V(0).CX(0, 2)
@@ -69,4 +90,17 @@ def q3_v0cx02() -> Circuit:
 def q3_cx01cz12x1rx0() -> Circuit:
     circuit = Circuit(3)
     circuit.CX(0, 1).CZ(1, 2).X(1).Rx(0.3, 0)
+    return circuit
+
+
+@pytest.fixture
+def q4_lcu1() -> Circuit:
+    circuit = Circuit(4)
+    circuit.Ry(0.78, 3).Ry(0.27, 2).CX(2, 3).Ry(0.58, 2).Ry(0.21, 3)
+    circuit.Ry(0.12, 0).Ry(0.56, 1)
+    circuit.add_gate(OpType.CnX, [0, 1, 2]).add_gate(OpType.CnX, [0, 1, 3])
+    circuit.X(0).X(1).add_gate(OpType.CnY, [0, 1, 2]).add_gate(OpType.CnY, [0, 1, 3]).X(
+        0
+    ).X(1)
+    circuit.Ry(-0.12, 0).Ry(-0.56, 1)
     return circuit

--- a/tests/test_cutensornet_backend.py
+++ b/tests/test_cutensornet_backend.py
@@ -76,6 +76,7 @@ def test_expectation_value() -> None:
     c = Circuit(2)
     c.H(0)
     c.CX(0, 1)
+    sv = np.array([c.get_statevector()]).T
     op = QubitPauliOperator(
         {
             QubitPauliString({Qubit(0): Pauli.Z, Qubit(1): Pauli.Z}): 1.0,
@@ -84,10 +85,13 @@ def test_expectation_value() -> None:
             QubitPauliString({Qubit(0): Pauli.Y}): -0.4j,
         }
     )
+    qubit_operator = op.to_sparse_matrix(2).todense()
     b = CuTensorNetBackend()
     c = b.get_compiled_circuit(c)
     expval = b.get_operator_expectation_value(c, op)
-    assert np.isclose(expval, 1.3)
+    print(sv.shape, qubit_operator.shape)
+    sv_expval = (sv.conj().T @ qubit_operator @ sv)[0, 0]
+    assert np.isclose(expval, sv_expval)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cutensornet_backend.py
+++ b/tests/test_cutensornet_backend.py
@@ -101,8 +101,12 @@ def test_expectation_value() -> None:
         pytest.lazy_fixture("q2_x0cx01cx10"),  # type: ignore
         pytest.lazy_fixture("q2_v0cx01cx10"),  # type: ignore
         pytest.lazy_fixture("q2_hadamard_test"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu1"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu2"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q4_lcu1"),  # type: ignore
     ],
 )
 def test_compile_convert_statevec_overlap(circuit: Circuit) -> None:

--- a/tests/test_cutensornet_backend.py
+++ b/tests/test_cutensornet_backend.py
@@ -89,7 +89,6 @@ def test_expectation_value() -> None:
     b = CuTensorNetBackend()
     c = b.get_compiled_circuit(c)
     expval = b.get_operator_expectation_value(c, op)
-    print(sv.shape, qubit_operator.shape)
     sv_expval = (sv.conj().T @ qubit_operator @ sv)[0, 0]
     assert np.isclose(expval, sv_expval)
 

--- a/tests/test_cutensornet_postselect.py
+++ b/tests/test_cutensornet_postselect.py
@@ -59,7 +59,6 @@ def test_postselect_qubits_state(circuit: Circuit, postselect_dict: dict) -> Non
     tn = TensorNetwork(circuit)
     ten_net = measure_qubits_state(tn, postselect_dict)
     result_cu = cq.contract(*ten_net.cuquantum_interleaved).flatten()
-    print(result_cu)
     assert np.allclose(result_cu, sv)
 
 

--- a/tests/test_cutensornet_postselect.py
+++ b/tests/test_cutensornet_postselect.py
@@ -1,15 +1,15 @@
 import numpy as np
 import cuquantum as cq
 import pytest
-from pytket.circuit import Qubit, Circuit
-from pytket.pauli import Pauli, QubitPauliString
+from pytket.circuit import Qubit, Circuit  # type: ignore
+from pytket.pauli import Pauli, QubitPauliString  # type: ignore
 from pytket.utils import QubitPauliOperator
-from pytket.extensions.cuquantum.backends import CuTensorNetBackend
-from pytket.extensions.cuquantum.tensor_network_convert import (  # type: ignore
+from pytket.extensions.cutensornet.backends import CuTensorNetBackend
+from pytket.extensions.cutensornet.tensor_network_convert import (  # type: ignore
     TensorNetwork,
     measure_qubits_state,
 )
-from pytket.extensions.cuquantum.utils import circuit_statevector_postselect
+from pytket.extensions.cutensornet.utils import circuit_statevector_postselect
 
 
 @pytest.mark.parametrize(
@@ -133,8 +133,6 @@ def test_expectation_value_postselect_4q_lcu(circuit_lcu_4q: Circuit) -> None:
     b = CuTensorNetBackend()
     c = b.get_compiled_circuit(circuit_lcu_4q)
     sv = sv * np.exp(1j * np.pi * c.phase)
-    sv_exp = (sv.conj().T @ op_matrix @ sv)[
-        0, 0
-    ]
+    sv_exp = (sv.conj().T @ op_matrix @ sv)[0, 0]
     ten_exp = b.get_operator_expectation_value_postselect(c.copy(), op, postselect_dict)
     assert np.isclose(ten_exp, sv_exp)

--- a/tests/test_cutensornet_postselect.py
+++ b/tests/test_cutensornet_postselect.py
@@ -92,7 +92,7 @@ def test_expectation_value_postselect_2q(
     sv_exp = (sv.conj().T @ op_matrix @ sv)[0, 0]
     b = CuTensorNetBackend()
     c = b.get_compiled_circuit(circuit_2q)
-    ten_exp = b.get_operator_expectation_value_postselect(c.copy(), op, postselect_dict)
+    ten_exp = b.get_operator_expectation_value(c.copy(), op, postselect_dict)
     assert np.isclose(ten_exp, sv_exp)
 
 
@@ -117,5 +117,5 @@ def test_expectation_value_postselect_4q_lcu(circuit_lcu_4q: Circuit) -> None:
     c = b.get_compiled_circuit(circuit_lcu_4q)
     sv = sv * np.exp(1j * np.pi * c.phase)
     sv_exp = (sv.conj().T @ op_matrix @ sv)[0, 0]
-    ten_exp = b.get_operator_expectation_value_postselect(c.copy(), op, postselect_dict)
+    ten_exp = b.get_operator_expectation_value(c.copy(), op, postselect_dict)
     assert np.isclose(ten_exp, sv_exp)

--- a/tests/test_cutensornet_postselect.py
+++ b/tests/test_cutensornet_postselect.py
@@ -1,0 +1,140 @@
+import numpy as np
+import cuquantum as cq
+import pytest
+from pytket.circuit import Qubit, Circuit
+from pytket.pauli import Pauli, QubitPauliString
+from pytket.utils import QubitPauliOperator
+from pytket.extensions.cuquantum.backends import CuTensorNetBackend
+from pytket.extensions.cuquantum.tensor_network_convert import (  # type: ignore
+    TensorNetwork,
+    measure_qubits_state,
+)
+from pytket.extensions.cuquantum.utils import circuit_statevector_postselect
+
+
+@pytest.mark.parametrize(
+    "circuit_2q",
+    [
+        pytest.lazy_fixture("q2_x0"),  # type: ignore
+        pytest.lazy_fixture("q2_x1"),  # type: ignore
+        pytest.lazy_fixture("q2_v0"),  # type: ignore
+        pytest.lazy_fixture("q2_x0cx01"),  # type: ignore
+        pytest.lazy_fixture("q2_x1cx10x1"),  # type: ignore
+        pytest.lazy_fixture("q2_x0cx01cx10"),  # type: ignore
+        pytest.lazy_fixture("q2_v0cx01cx10"),  # type: ignore
+        pytest.lazy_fixture("q2_hadamard_test"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu1"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu2"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu3"),  # type: ignore
+    ],
+)
+def test_postselect_qubits_state_2q(circuit_2q: Circuit) -> None:
+    measurement_dict = {Qubit("q", 0): 0}
+    sv = circuit_statevector_postselect(circuit_2q, measurement_dict)
+    tn = TensorNetwork(circuit_2q)
+    ten_net = measure_qubits_state(tn, measurement_dict)
+    result_cu = cq.contract(*ten_net.cuquantum_interleaved).flatten().round(10)
+    assert np.allclose(result_cu, sv)
+
+    measurement_dict = {Qubit("q", 0): 1}
+    sv = circuit_statevector_postselect(circuit_2q, measurement_dict)
+    tn = TensorNetwork(circuit_2q)
+    ten_net = measure_qubits_state(tn, measurement_dict)
+    result_cu = cq.contract(*ten_net.cuquantum_interleaved).flatten().round(10)
+    assert np.allclose(result_cu, sv)
+
+
+@pytest.mark.parametrize(
+    "circuit_3q",
+    [
+        pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
+        pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q4_lcu1"),  # type: ignore
+    ],
+)
+def test_postselect_qubits_state_3q(circuit_3q: Circuit) -> None:
+    postselect_dict = {Qubit("q", 0): 0, Qubit("q", 1): 0}
+    sv = circuit_statevector_postselect(circuit_3q, postselect_dict.copy())
+    tn = TensorNetwork(circuit_3q)
+    ten_net = measure_qubits_state(tn, postselect_dict)
+    result_cu = cq.contract(*ten_net.cuquantum_interleaved).flatten()
+    print(result_cu)
+    assert np.allclose(result_cu, sv)
+
+    measurement_dict = {Qubit("q", 0): 1, Qubit("q", 1): 1}
+    sv = circuit_statevector_postselect(circuit_3q, measurement_dict.copy())
+    tn = TensorNetwork(circuit_3q)
+    ten_net = measure_qubits_state(tn, measurement_dict)
+    result_cu = cq.contract(*ten_net.cuquantum_interleaved).flatten()
+    assert np.allclose(result_cu, sv)
+
+
+@pytest.mark.parametrize(
+    "circuit_2q",
+    [
+        pytest.lazy_fixture("q2_x0"),  # type: ignore
+        pytest.lazy_fixture("q2_x1"),  # type: ignore
+        pytest.lazy_fixture("q2_v0"),  # type: ignore
+        pytest.lazy_fixture("q2_x0cx01"),  # type: ignore
+        pytest.lazy_fixture("q2_x1cx10x1"),  # type: ignore
+        pytest.lazy_fixture("q2_hadamard_test"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu1"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu2"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu3"),  # type: ignore
+    ],
+)
+def test_expectation_value_postselect_2q(circuit_2q: Circuit) -> None:
+    postselect_dict = {Qubit("q", 1): 0}
+    op = QubitPauliOperator(
+        {
+            QubitPauliString({Qubit(0): Pauli.Z}): 1.0,
+        }
+    )
+    op_matrix = op.to_sparse_matrix(1).todense()
+    sv = np.array([circuit_statevector_postselect(circuit_2q, postselect_dict)]).T
+    sv_exp = (sv.conj().T @ op_matrix @ sv)[0, 0]
+    b = CuTensorNetBackend()
+    c = b.get_compiled_circuit(circuit_2q)
+    ten_exp = b.get_operator_expectation_value_postselect(c.copy(), op, postselect_dict)
+    assert np.isclose(ten_exp, sv_exp)
+
+    postselect_dict = {Qubit("q", 1): 1}
+    op = QubitPauliOperator(
+        {
+            QubitPauliString({Qubit(0): Pauli.Z}): 1.0,
+        }
+    )
+    op_matrix = op.to_sparse_matrix(1).todense()
+    sv = np.array([circuit_statevector_postselect(circuit_2q, postselect_dict)]).T
+    sv_exp = (sv.conj().T @ op_matrix @ sv)[0, 0]
+    b = CuTensorNetBackend()
+    c = b.get_compiled_circuit(circuit_2q)
+    ten_exp = b.get_operator_expectation_value_postselect(c.copy(), op, postselect_dict)
+    assert np.isclose(ten_exp, sv_exp)
+
+
+@pytest.mark.parametrize(
+    "circuit_lcu_4q",
+    [
+        pytest.lazy_fixture("q4_lcu1"),  # type: ignore
+    ],
+)
+def test_expectation_value_postselect_4q_lcu(circuit_lcu_4q: Circuit) -> None:
+    postselect_dict = {Qubit("q", 2): 0, Qubit("q", 3): 0}
+    op = QubitPauliOperator(
+        {
+            QubitPauliString({Qubit(0): Pauli.Z, Qubit(1): Pauli.X}): 0.25,
+        }
+    )
+    op_matrix = op.to_sparse_matrix(2).todense()
+    sv = np.array(
+        [circuit_statevector_postselect(circuit_lcu_4q, postselect_dict.copy())]
+    ).T
+    b = CuTensorNetBackend()
+    c = b.get_compiled_circuit(circuit_lcu_4q)
+    sv = sv * np.exp(1j * np.pi * c.phase)
+    sv_exp = (sv.conj().T @ op_matrix @ sv)[
+        0, 0
+    ]
+    ten_exp = b.get_operator_expectation_value_postselect(c.copy(), op, postselect_dict)
+    assert np.isclose(ten_exp, sv_exp)

--- a/tests/test_cutensornet_postselect.py
+++ b/tests/test_cutensornet_postselect.py
@@ -1,5 +1,5 @@
 import numpy as np
-import cuquantum as cq
+import cuquantum as cq  # type: ignore
 import pytest
 from pytket.circuit import Qubit, Circuit  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore

--- a/tests/test_cutensornet_postselect.py
+++ b/tests/test_cutensornet_postselect.py
@@ -81,7 +81,6 @@ def test_postselect_qubits_state(circuit: Circuit, postselect_dict: dict) -> Non
 def test_expectation_value_postselect_2q(
     circuit_2q: Circuit, postselect_dict: dict
 ) -> None:
-    postselect_dict = {Qubit("q", 1): 0}
     op = QubitPauliOperator(
         {
             QubitPauliString({Qubit(0): Pauli.Z}): 1.0,

--- a/tests/test_cutensornet_postselect.py
+++ b/tests/test_cutensornet_postselect.py
@@ -28,44 +28,38 @@ from pytket.extensions.cutensornet.utils import circuit_statevector_postselect
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
     ],
 )
-def test_postselect_qubits_state_2q(circuit_2q: Circuit) -> None:
-    measurement_dict = {Qubit("q", 0): 0}
-    sv = circuit_statevector_postselect(circuit_2q, measurement_dict)
+@pytest.mark.parametrize("postselect_dict", [{Qubit("q", 0): 0}, {Qubit("q", 0): 1}])
+def test_postselect_qubits_state_2q(circuit_2q: Circuit, postselect_dict: dict) -> None:
+    sv = circuit_statevector_postselect(circuit_2q, postselect_dict)
     tn = TensorNetwork(circuit_2q)
-    ten_net = measure_qubits_state(tn, measurement_dict)
-    result_cu = cq.contract(*ten_net.cuquantum_interleaved).flatten().round(10)
-    assert np.allclose(result_cu, sv)
-
-    measurement_dict = {Qubit("q", 0): 1}
-    sv = circuit_statevector_postselect(circuit_2q, measurement_dict)
-    tn = TensorNetwork(circuit_2q)
-    ten_net = measure_qubits_state(tn, measurement_dict)
+    ten_net = measure_qubits_state(tn, postselect_dict)
     result_cu = cq.contract(*ten_net.cuquantum_interleaved).flatten().round(10)
     assert np.allclose(result_cu, sv)
 
 
 @pytest.mark.parametrize(
-    "circuit_3q",
+    "circuit",
     [
         pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
         pytest.lazy_fixture("q4_lcu1"),  # type: ignore
     ],
 )
-def test_postselect_qubits_state_3q(circuit_3q: Circuit) -> None:
-    postselect_dict = {Qubit("q", 0): 0, Qubit("q", 1): 0}
-    sv = circuit_statevector_postselect(circuit_3q, postselect_dict.copy())
-    tn = TensorNetwork(circuit_3q)
+@pytest.mark.parametrize(
+    "postselect_dict",
+    [
+        {Qubit("q", 0): 0, Qubit("q", 1): 0},
+        {Qubit("q", 0): 1, Qubit("q", 1): 1},
+        {Qubit("q", 0): 0, Qubit("q", 1): 1},
+        {Qubit("q", 0): 1, Qubit("q", 1): 1},
+    ],
+)
+def test_postselect_qubits_state(circuit: Circuit, postselect_dict: dict) -> None:
+    sv = circuit_statevector_postselect(circuit, postselect_dict.copy())
+    tn = TensorNetwork(circuit)
     ten_net = measure_qubits_state(tn, postselect_dict)
     result_cu = cq.contract(*ten_net.cuquantum_interleaved).flatten()
     print(result_cu)
-    assert np.allclose(result_cu, sv)
-
-    measurement_dict = {Qubit("q", 0): 1, Qubit("q", 1): 1}
-    sv = circuit_statevector_postselect(circuit_3q, measurement_dict.copy())
-    tn = TensorNetwork(circuit_3q)
-    ten_net = measure_qubits_state(tn, measurement_dict)
-    result_cu = cq.contract(*ten_net.cuquantum_interleaved).flatten()
     assert np.allclose(result_cu, sv)
 
 
@@ -83,22 +77,11 @@ def test_postselect_qubits_state_3q(circuit_3q: Circuit) -> None:
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
     ],
 )
-def test_expectation_value_postselect_2q(circuit_2q: Circuit) -> None:
+@pytest.mark.parametrize("postselect_dict", [{Qubit("q", 0): 0}, {Qubit("q", 0): 1}])
+def test_expectation_value_postselect_2q(
+    circuit_2q: Circuit, postselect_dict: dict
+) -> None:
     postselect_dict = {Qubit("q", 1): 0}
-    op = QubitPauliOperator(
-        {
-            QubitPauliString({Qubit(0): Pauli.Z}): 1.0,
-        }
-    )
-    op_matrix = op.to_sparse_matrix(1).todense()
-    sv = np.array([circuit_statevector_postselect(circuit_2q, postselect_dict)]).T
-    sv_exp = (sv.conj().T @ op_matrix @ sv)[0, 0]
-    b = CuTensorNetBackend()
-    c = b.get_compiled_circuit(circuit_2q)
-    ten_exp = b.get_operator_expectation_value_postselect(c.copy(), op, postselect_dict)
-    assert np.isclose(ten_exp, sv_exp)
-
-    postselect_dict = {Qubit("q", 1): 1}
     op = QubitPauliOperator(
         {
             QubitPauliString({Qubit(0): Pauli.Z}): 1.0,

--- a/tests/test_cutensornet_postselect.py
+++ b/tests/test_cutensornet_postselect.py
@@ -76,7 +76,7 @@ def test_postselect_qubits_state(circuit: Circuit, postselect_dict: dict) -> Non
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
     ],
 )
-@pytest.mark.parametrize("postselect_dict", [{Qubit("q", 0): 0}, {Qubit("q", 0): 1}])
+@pytest.mark.parametrize("postselect_dict", [{Qubit("q", 1): 0}, {Qubit("q", 1): 1}])
 def test_expectation_value_postselect_2q(
     circuit_2q: Circuit, postselect_dict: dict
 ) -> None:

--- a/tests/test_tensor_network_convert.py
+++ b/tests/test_tensor_network_convert.py
@@ -47,8 +47,12 @@ def circuit_overlap_contract(circuit_ket: Circuit) -> float:
         pytest.lazy_fixture("q2_x0cx01cx10"),  # type: ignore
         pytest.lazy_fixture("q2_v0cx01cx10"),  # type: ignore
         pytest.lazy_fixture("q2_hadamard_test"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu1"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu2"),  # type: ignore
+        pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q4_lcu1"),  # type: ignore
     ],
 )
 def test_convert_statevec_overlap(circuit: Circuit) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
+import numpy
 from pytket.extensions.cutensornet.utils import circuit_statevector_postselect
 from pytket import Circuit, Qubit  # type: ignore
-import numpy
 
 
 def test_circuit_statevector_postselect() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+from pytket.extensions.cutensornet.utils import circuit_statevector_postselect
+from pytket import Circuit, Qubit  # type: ignore
+import numpy
+
+
+def test_circuit_statevector_postselect() -> None:
+    circ = Circuit(3).Ry(0.1, 0).Ry(0.2, 1).Ry(0.2, 2)
+    sv = circ.get_statevector()
+
+    n_state_qubits = 2
+
+    sv_post_select = sv[: 2**n_state_qubits]
+
+    post_select_dict = {Qubit(0): 0}
+
+    sv_postselect = circuit_statevector_postselect(circ, post_select_dict)
+
+    numpy.testing.assert_array_equal(sv_postselect, sv_post_select)
+
+    circ = Circuit(3).Ry(0.1, 0).Ry(0.2, 1).Ry(0.2, 2)
+    sv = circ.get_statevector()
+
+    n_state_qubits = 1
+
+    sv_post_select = sv[: 2**n_state_qubits]
+
+    post_select_dict = {Qubit(0): 0, Qubit(1): 0}
+
+    sv_postselect = circuit_statevector_postselect(circ, post_select_dict)
+
+    numpy.testing.assert_array_equal(sv_postselect, sv_post_select)


### PR DESCRIPTION
Added post selection capability for expectational value tensor networks

A dict must be supplied into a new fucntion called .get_expectational_value_postselect(). 
I chose to make a new function as to not deviate the original function from the original .get_expectational_value() api. However the post selection coud easily be integrated if we choose too.

The are two fucntions which handle post selection: _measure_qubit_state and measure_qubits_state. Currently these just cap the post selection qubits with |0><0| or |1><1|. Therefore it does not not work with the pytket api atm. They also do not currently work with mid circuit measurment. But I envisage this will not be a huge amount of work.

Finally I added a map which relates the sticky index to the pytket qubit object. This makes it compatible with qubitids other that q[i] for example a[i] now work.

Extra LCU tests have been added.

An extra utils file was created to hold the statevector poste selection functions. These needed to be created to test the tensor network post selection. They will be going to pytket as a PR and will hence be removed when that happens.

I can add some example notebookes if you think this would be helpful.