### PR TITLE
Refactor init_cutensornet

### DIFF
--- a/docs/modules/mps.rst
+++ b/docs/modules/mps.rst
@@ -21,7 +21,7 @@ Classes
 .. autoclass:: pytket.extensions.cutensornet.mps.MPS()
 
     .. automethod:: __init__
-    .. automethod:: init_cutensornet
+    .. automethod:: set_libhandle
     .. automethod:: apply_gate
     .. automethod:: vdot
     .. automethod:: canonicalise
@@ -42,6 +42,8 @@ Classes
     :show-inheritance:
 
     .. automethod:: __init__
+
+.. autoclass:: pytket.extensions.cutensornet.mps.CuTensorNetHandle
 
 .. autoclass:: pytket.extensions.cutensornet.mps.Tensor()
 

--- a/docs/modules/mps.rst
+++ b/docs/modules/mps.rst
@@ -29,6 +29,7 @@ Classes
     .. automethod:: get_virtual_dimensions
     .. automethod:: get_physical_bond
     .. automethod:: get_physical_dimension
+    .. automethod:: get_device_id
     .. automethod:: is_valid
     .. automethod:: copy
     .. automethod:: __len__

--- a/docs/modules/mps.rst
+++ b/docs/modules/mps.rst
@@ -21,7 +21,6 @@ Classes
 .. autoclass:: pytket.extensions.cutensornet.mps.MPS()
 
     .. automethod:: __init__
-    .. automethod:: set_libhandle
     .. automethod:: apply_gate
     .. automethod:: vdot
     .. automethod:: canonicalise
@@ -31,6 +30,7 @@ Classes
     .. automethod:: get_physical_dimension
     .. automethod:: get_device_id
     .. automethod:: is_valid
+    .. automethod:: update_libhandle
     .. automethod:: copy
     .. automethod:: __len__
 

--- a/examples/mpi/mpi_overlap_bcast_mps.py
+++ b/examples/mpi/mpi_overlap_bcast_mps.py
@@ -120,11 +120,9 @@ time0 = MPI.Wtime()
 for proc_i in range(n_procs):
     mps_list += comm.bcast(this_proc_mps, proc_i)
 
-# Change device ID and initialise cuTensorNet for this process
-# TODO: I don't think this is moving mem between GPUs on same node. Look into NCCL.
+# Initialise cuTensorNet for this process
 with CuTensorNetHandle(device_id) as libhandle:  # Different handle for each process
     for mps in mps_list:
-        mps._device_id = device_id
         mps.set_libhandle(libhandle)
 
     time1 = MPI.Wtime()

--- a/examples/mps_tutorial.ipynb
+++ b/examples/mps_tutorial.ipynb
@@ -97,7 +97,7 @@
        "\n",
        "\n",
        "\n",
-       "    &lt;div id=&#34;circuit-display-vue-container-da097ef3-4fd3-4518-bdce-4d5b2c9dbf1c&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-3af59909-1a56-4473-9a34-647cee86f213&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
        "        &lt;div style=&#34;display: none&#34;&gt;\n",
        "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.2&#34;], &#34;type&#34;: &#34;Ry&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;, &#34;0.5&#34;, &#34;0.7&#34;], &#34;type&#34;: &#34;TK2&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [4]], [&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.1&#34;], &#34;type&#34;: &#34;ZZPhase&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]], [[&#34;q&#34;, [3]], [&#34;q&#34;, [3]]], [[&#34;q&#34;, [4]], [&#34;q&#34;, [4]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [3]], [&#34;q&#34;, [4]]]}&lt;/div&gt;\n",
        "        &lt;/div&gt;\n",
@@ -107,7 +107,7 @@
        "        &gt;&lt;/circuit-display-container&gt;\n",
        "    &lt;/div&gt;\n",
        "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
-       "      const circuitRendererUid = &#34;da097ef3-4fd3-4518-bdce-4d5b2c9dbf1c&#34;;\n",
+       "      const circuitRendererUid = &#34;3af59909-1a56-4473-9a34-647cee86f213&#34;;\n",
        "      const displayOptions = JSON.parse(&#39;{}&#39;);\n",
        "\n",
        "      // Script to initialise the circuit renderer app\n",
@@ -168,7 +168,11 @@
    "id": "a9ede80b-32d0-4d43-b910-099dcc2a8a95",
    "metadata": {},
    "source": [
-    "For **exact** simulation, simply call the `simulate` function on the circuit and choose a contraction algorithm. To learn more about the contraction algorithms we provide see the *Contraction algorithms* section of this notebook."
+    "For **exact** simulation, simply call the `simulate` function on the circuit and choose a contraction algorithm. To learn more about the contraction algorithms we provide see the *Contraction algorithms* section of this notebook.\n",
+    "\n",
+    "**NOTE**: whenever you wish to generate an `MPS` object or execute calculations on it you must do so within a `with CuTensorNetHandle() as libhandle:` block; this will initialise the cuTensorNetwork library for you, and destroy its handles at the end of the `with` block. You will need to pass the `libhandle` to the `MPS` object via the method that generates it (in the snippet below, `simulate`), or if already initialised, pass it via the `update_libhandle` method.\n",
+    "\n",
+    "Due to the nature of Jupyter notebooks, we will be starting most of these cells with a `with CuTensorNetHandle() as libhandle:`. However, in a standard script, all of these cells would be grouped together and a single `with CuTensorNetHandle() as libhandle:` statement would be necessary at the beginning of the script."
    ]
   },
   {
@@ -178,7 +182,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_mps = simulate(my_circ, ContractionAlg.MPSxGate)"
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    my_mps = simulate(libhandle, my_circ, ContractionAlg.MPSxGate)"
    ]
   },
   {
@@ -198,9 +203,7 @@
     "\n",
     "### Obtain an amplitude from an MPS\n",
     "\n",
-    "Let's first see how to get the amplitude of the state `|10100>` from the output of the previous circuit.\n",
-    "\n",
-    "**NOTE**: whenever you wish to do calculations on an `MPS` object you must include these within a `with CuTensorNetHandle() as libhandle:` block; this will initialise the cuTensorNetwork library for you, and destroy its handles at the end of the `with` block. You will need to pass the `libhandle` to the `MPS` object via the `set_libhandle` method."
+    "Let's first see how to get the amplitude of the state `|10100>` from the output of the previous circuit."
    ]
   },
   {
@@ -220,7 +223,7 @@
    "source": [
     "state = int('10100', 2)\n",
     "with CuTensorNetHandle() as libhandle:\n",
-    "    my_mps.set_libhandle(libhandle)\n",
+    "    my_mps.update_libhandle(libhandle)\n",
     "    amplitude = get_amplitude(my_mps, state)\n",
     "print(amplitude)"
    ]
@@ -254,7 +257,7 @@
     "\n",
     "correct_amplitude = [False] * (2**n_qubits)\n",
     "with CuTensorNetHandle() as libhandle:\n",
-    "    my_mps.set_libhandle(libhandle)\n",
+    "    my_mps.update_libhandle(libhandle)\n",
     "    for i in range(2**n_qubits):\n",
     "        correct_amplitude[i] = np.isclose(state_vector[i], get_amplitude(my_mps, i))\n",
     "\n",
@@ -289,7 +292,7 @@
    ],
    "source": [
     "with CuTensorNetHandle() as libhandle:\n",
-    "    my_mps.set_libhandle(libhandle)\n",
+    "    my_mps.update_libhandle(libhandle)\n",
     "    norm_sq = my_mps.vdot(my_mps)\n",
     "\n",
     "print(\"As expected, the squared norm of a state is 1\")\n",
@@ -319,7 +322,8 @@
     "other_circ.Ry(0.7, 3)\n",
     "\n",
     "# Simulate them\n",
-    "other_mps = simulate(other_circ, ContractionAlg.MPSxGate)"
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    other_mps = simulate(libhandle, other_circ, ContractionAlg.MPSxGate)"
    ]
   },
   {
@@ -347,7 +351,7 @@
    ],
    "source": [
     "with CuTensorNetHandle() as libhandle:\n",
-    "    my_mps.set_libhandle(libhandle)\n",
+    "    my_mps.update_libhandle(libhandle)\n",
     "    inner_product = my_mps.vdot(other_mps)\n",
     "    \n",
     "my_state = my_circ.get_statevector()\n",
@@ -398,7 +402,7 @@
        "\n",
        "\n",
        "\n",
-       "    &lt;div id=&#34;circuit-display-vue-container-3f4e410b-6d42-4372-b0f0-09915a57f9e7&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-7383db6e-1623-4936-94f4-42a52930c17e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
        "        &lt;div style=&#34;display: none&#34;&gt;\n",
        "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;ZZPhase&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.8&#34;], &#34;type&#34;: &#34;Ry&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.7&#34;], &#34;type&#34;: &#34;XXPhase&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.1&#34;, &#34;0.2&#34;, &#34;0.4&#34;], &#34;type&#34;: &#34;TK2&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]], [[&#34;q&#34;, [3]], [&#34;q&#34;, [3]]], [[&#34;q&#34;, [4]], [&#34;q&#34;, [4]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [3]], [&#34;q&#34;, [4]]]}&lt;/div&gt;\n",
        "        &lt;/div&gt;\n",
@@ -408,7 +412,7 @@
        "        &gt;&lt;/circuit-display-container&gt;\n",
        "    &lt;/div&gt;\n",
        "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
-       "      const circuitRendererUid = &#34;3f4e410b-6d42-4372-b0f0-09915a57f9e7&#34;;\n",
+       "      const circuitRendererUid = &#34;7383db6e-1623-4936-94f4-42a52930c17e&#34;;\n",
        "      const displayOptions = JSON.parse(&#39;{}&#39;);\n",
        "\n",
        "      // Script to initialise the circuit renderer app\n",
@@ -480,10 +484,11 @@
     }
    ],
    "source": [
-    "try:\n",
-    "    simulate(bad_circ, ContractionAlg.MPSxGate)\n",
-    "except RuntimeError as e:\n",
-    "    print(e)"
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    try:\n",
+    "        simulate(libhandle, bad_circ, ContractionAlg.MPSxGate)\n",
+    "    except RuntimeError as e:\n",
+    "        print(e)"
    ]
   },
   {
@@ -525,7 +530,7 @@
        "\n",
        "\n",
        "\n",
-       "    &lt;div id=&#34;circuit-display-vue-container-23b08f17-b76b-4557-8bcd-fe54b43aad79&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-4bee7c61-c149-47ac-9c11-ebe151fa24f3&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
        "        &lt;div style=&#34;display: none&#34;&gt;\n",
        "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.8&#34;], &#34;type&#34;: &#34;Ry&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [0]], [&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;SWAP&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [4]], [&#34;node&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [2]], [&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;ZZPhase&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [1]], [&#34;node&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [3]], [&#34;node&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.7&#34;], &#34;type&#34;: &#34;XXPhase&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [3]], [&#34;node&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;SWAP&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [2]], [&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;SWAP&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [1]], [&#34;node&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.1&#34;, &#34;0.2&#34;, &#34;0.4&#34;], &#34;type&#34;: &#34;TK2&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;node&#34;, [0]], [&#34;node&#34;, [0]]], [[&#34;node&#34;, [1]], [&#34;node&#34;, [1]]], [[&#34;node&#34;, [2]], [&#34;node&#34;, [2]]], [[&#34;node&#34;, [3]], [&#34;node&#34;, [3]]], [[&#34;node&#34;, [4]], [&#34;node&#34;, [4]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;node&#34;, [0]], [&#34;node&#34;, [1]], [&#34;node&#34;, [2]], [&#34;node&#34;, [3]], [&#34;node&#34;, [4]]]}&lt;/div&gt;\n",
        "        &lt;/div&gt;\n",
@@ -535,7 +540,7 @@
        "        &gt;&lt;/circuit-display-container&gt;\n",
        "    &lt;/div&gt;\n",
        "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
-       "      const circuitRendererUid = &#34;23b08f17-b76b-4557-8bcd-fe54b43aad79&#34;;\n",
+       "      const circuitRendererUid = &#34;4bee7c61-c149-47ac-9c11-ebe151fa24f3&#34;;\n",
        "      const displayOptions = JSON.parse(&#39;{}&#39;);\n",
        "\n",
        "      // Script to initialise the circuit renderer app\n",
@@ -617,11 +622,9 @@
     }
    ],
    "source": [
-    "prep_mps = simulate(prep_circ, ContractionAlg.MPSxGate)\n",
-    "\n",
-    "print(\"Did simulation succeed?\")\n",
     "with CuTensorNetHandle() as libhandle:\n",
-    "    prep_mps.set_libhandle(libhandle)\n",
+    "    prep_mps = simulate(libhandle, prep_circ, ContractionAlg.MPSxGate)\n",
+    "    print(\"Did simulation succeed?\")\n",
     "    print(prep_mps.is_valid())"
    ]
   },
@@ -700,16 +703,17 @@
      "output_type": "stream",
      "text": [
       "Time taken by approximate contraction with bound chi:\n",
-      "1.66 seconds\n",
+      "1.51 seconds\n",
       "\n",
       "Lower bound of the fidelity:\n",
-      "0.4776\n"
+      "0.2402\n"
      ]
     }
    ],
    "source": [
     "start = time()\n",
-    "bound_chi_mps = simulate(circuit, ContractionAlg.MPSxGate, chi=16)\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    bound_chi_mps = simulate(libhandle, circuit, ContractionAlg.MPSxGate, chi=16)\n",
     "end = time()\n",
     "print(\"Time taken by approximate contraction with bound chi:\")\n",
     "print(f\"{round(end-start,2)} seconds\")\n",
@@ -736,16 +740,17 @@
      "output_type": "stream",
      "text": [
       "Time taken by approximate contraction with fixed truncation fidelity:\n",
-      "1.72 seconds\n",
+      "1.55 seconds\n",
       "\n",
       "Lower bound of the fidelity:\n",
-      "0.4596\n"
+      "0.4611\n"
      ]
     }
    ],
    "source": [
     "start = time()\n",
-    "fixed_fidelity_mps = simulate(circuit, ContractionAlg.MPSxGate, truncation_fidelity=0.99)\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    fixed_fidelity_mps = simulate(libhandle, circuit, ContractionAlg.MPSxGate, truncation_fidelity=0.99)\n",
     "end = time()\n",
     "print(\"Time taken by approximate contraction with fixed truncation fidelity:\")\n",
     "print(f\"{round(end-start,2)} seconds\")\n",
@@ -790,14 +795,15 @@
      "output_type": "stream",
      "text": [
       "MPSxGate\n",
-      "\tTime taken: 1.11 seconds\n",
-      "\tLower bound of the fidelity: 0.4776\n"
+      "\tTime taken: 1.14 seconds\n",
+      "\tLower bound of the fidelity: 0.2408\n"
      ]
     }
    ],
    "source": [
     "start = time()\n",
-    "fixed_fidelity_mps = simulate(circuit, ContractionAlg.MPSxGate, chi=16)\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    fixed_fidelity_mps = simulate(libhandle, circuit, ContractionAlg.MPSxGate, chi=16)\n",
     "end = time()\n",
     "print(\"MPSxGate\")\n",
     "print(f\"\\tTime taken: {round(end-start,2)} seconds\")\n",
@@ -815,14 +821,15 @@
      "output_type": "stream",
      "text": [
       "MPSxMPO, default parameters\n",
-      "\tTime taken: 9.24 seconds\n",
-      "\tLower bound of the fidelity: 0.523\n"
+      "\tTime taken: 12.49 seconds\n",
+      "\tLower bound of the fidelity: 0.301\n"
      ]
     }
    ],
    "source": [
     "start = time()\n",
-    "fixed_fidelity_mps = simulate(circuit, ContractionAlg.MPSxMPO, chi=16)\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    fixed_fidelity_mps = simulate(libhandle, circuit, ContractionAlg.MPSxMPO, chi=16)\n",
     "end = time()\n",
     "print(\"MPSxMPO, default parameters\")\n",
     "print(f\"\\tTime taken: {round(end-start,2)} seconds\")\n",
@@ -840,14 +847,15 @@
      "output_type": "stream",
      "text": [
       "MPSxMPO, custom parameters\n",
-      "\tTime taken: 10.61 seconds\n",
-      "\tLower bound of the fidelity: 0.648\n"
+      "\tTime taken: 27.98 seconds\n",
+      "\tLower bound of the fidelity: 0.3638\n"
      ]
     }
    ],
    "source": [
     "start = time()\n",
-    "fixed_fidelity_mps = simulate(circuit, ContractionAlg.MPSxMPO, k=8, optim_delta=1e-15, chi=16)\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    fixed_fidelity_mps = simulate(libhandle, circuit, ContractionAlg.MPSxMPO, k=8, optim_delta=1e-15, chi=16)\n",
     "end = time()\n",
     "print(\"MPSxMPO, custom parameters\")\n",
     "print(f\"\\tTime taken: {round(end-start,2)} seconds\")\n",

--- a/examples/mps_tutorial.ipynb
+++ b/examples/mps_tutorial.ipynb
@@ -13,6 +13,7 @@
     "from pytket.circuit.display import render_circuit_jupyter\n",
     "\n",
     "from pytket.extensions.cutensornet.mps import (\n",
+    "    CuTensorNetHandle,\n",
     "    ContractionAlg,\n",
     "    simulate, \n",
     "    get_amplitude, \n",
@@ -38,21 +39,21 @@
     "\n",
     "![image.png](attachment:318cc014-ad93-4722-85e8-12f9b2e20ca3.png)\n",
     "\n",
-    "Each of these circles corresponds to a tensor which. We refer to each leg of a tensor as a *bond* and the number of bonds a tensor has is its *rank*. In code, a tensor is just a multidimensional array:\n",
+    "Each of these circles corresponds to a tensor. We refer to each leg of a tensor as a *bond* and the number of bonds a tensor has is its *rank*. In code, a tensor is just a multidimensional array:\n",
     "```\n",
     "    tensor[i][j][k] = v\n",
     "```\n",
-    "In the case above, we are assigning an entry value `v` of a rank-3 tensor (one `[ ]` coordinate per bond). Each bond allows a different number of values for its indices; for instance `0 <= i < 4` would mean that the first bond of our tensor can take up to four different indices; we refer to this as the *dimension* of the bond. We refer to the bonds connecting different tensors in the MPS as *virtual bonds* (and, of course, connected bonds must agree on their dimension); the maximum allowed value for the dimension of virtual bonds is often denoted by the greek letter `chi`. The open bonds are known as *physical bonds* and, in our case, each will correspond to a qubit; hence, they have dimension `2` -- the dimension of the vector space of a single qubit. \n",
+    "In the case above, we are assigning an entry value `v` of a rank-3 tensor (one `[ ]` coordinate per bond). Each bond allows a different number of values for its indices; for instance `0 <= i < 4` would mean that the first bond of our tensor can take up to four different indices; we refer to this as the *dimension* of the bond. We refer to the bonds connecting different tensors in the MPS as *virtual bonds*; the maximum allowed value for the dimension of virtual bonds is often denoted by the greek letter `chi`. The open bonds are known as *physical bonds* and, in our case, each will correspond to a qubit; hence, they have dimension `2` -- the dimension of the vector space of a single qubit. \n",
     "\n",
-    "In essence, whenever we want to apply a gate to certain qubit we will connect a tensor (matrix) representing the gate to the corresponding physical bond and *contract* the network back to an MPS form (tensor contraction is a generalisation of matrix multiplication to multi-dimensional arrays). Whenever a two-qubit gate is applied, after contraction the entanglement information will be kept in the degrees of freedom of the virtual bonds. As such, the dimension of the virtual bonds will generally increase exponentially as we apply entangling gates, leading to large memory footprints of the tensors and, consequently, long runtime for tensor contraction. We provide functionalities to limit the growth of the dimension of the virtual bonds, keeping resource consumption in check. Read the *Approximate simulation* section on this notebook to learn more.\n",
+    "In essence, whenever we want to apply a gate to certain qubit we will connect a tensor (matrix) representing the gate to the corresponding physical bond and *contract* the network back to an MPS form (tensor contraction is a generalisation of matrix multiplication to multidimensional arrays). Whenever a two-qubit gate is applied, the entanglement information after contraction will be kept in the degrees of freedom of the virtual bonds. As such, the dimension of the virtual bonds will generally increase exponentially as we apply entangling gates, leading to large memory footprints of the tensors and, consequently, long runtime for tensor contraction. We provide functionalities to limit the growth of the dimension of the virtual bonds, keeping resource consumption in check. Read the *Approximate simulation* section on this notebook to learn more.\n",
     "\n",
-    "**NOTE**: MPS methods work best when circuits only contain gates that act between nearest-neighbours in a line. Our main function `simulate` deals with circuits containing gates with arbitrary connectivity by first applying a routing algorithm using `pytket`. This will add multiple `SWAP` gates to the circuit that *need* to be simulated explicitly within the MPS, increasing the resources required considerably. In the future, we will support other tensor network state approaches that do not suffer so drastically from this restrictive connectivity.\n",
+    "**NOTE**: MPS methods can only be applied to circuits that only contain gates that act between nearest-neighbours in a line. If your circuit does not satisfy this constraint, you can use the `prepare_circuit` function (see the *Preparing the circuit* section); this will add multiple `SWAP` gates to the circuit that *need* to be simulated explicitly within the MPS, increasing the resources required considerably. In the future, we will support other tensor network state approaches that do not suffer so drastically from this restrictive connectivity.\n",
     "\n",
     "**References**: To read more about MPS we recommend the following papers.\n",
     "* For an introduction to MPS and its canonical form: https://arxiv.org/abs/1901.05824.\n",
     "* For a description of the `MPSxGate` algorithm we provide: https://arxiv.org/abs/2002.07730.\n",
     "* For a description of the `MPSxMPO` algorithm we provide: https://arxiv.org/abs/2207.05612.\n",
-    "* For insights on the reationship of truncation error and the error model in a quantum computer: https://arxiv.org/abs/2004.02388"
+    "* For insights on the reationship between truncation error and the error model in a quantum computer: https://arxiv.org/abs/2004.02388"
    ]
   },
   {
@@ -96,7 +97,7 @@
        "\n",
        "\n",
        "\n",
-       "    &lt;div id=&#34;circuit-display-vue-container-bc5baa0a-88ef-4f33-bca4-e36e3b8e3504&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-da097ef3-4fd3-4518-bdce-4d5b2c9dbf1c&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
        "        &lt;div style=&#34;display: none&#34;&gt;\n",
        "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.2&#34;], &#34;type&#34;: &#34;Ry&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;, &#34;0.5&#34;, &#34;0.7&#34;], &#34;type&#34;: &#34;TK2&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [4]], [&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.1&#34;], &#34;type&#34;: &#34;ZZPhase&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]], [[&#34;q&#34;, [3]], [&#34;q&#34;, [3]]], [[&#34;q&#34;, [4]], [&#34;q&#34;, [4]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [3]], [&#34;q&#34;, [4]]]}&lt;/div&gt;\n",
        "        &lt;/div&gt;\n",
@@ -106,7 +107,7 @@
        "        &gt;&lt;/circuit-display-container&gt;\n",
        "    &lt;/div&gt;\n",
        "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
-       "      const circuitRendererUid = &#34;bc5baa0a-88ef-4f33-bca4-e36e3b8e3504&#34;;\n",
+       "      const circuitRendererUid = &#34;da097ef3-4fd3-4518-bdce-4d5b2c9dbf1c&#34;;\n",
        "      const displayOptions = JSON.parse(&#39;{}&#39;);\n",
        "\n",
        "      // Script to initialise the circuit renderer app\n",
@@ -195,11 +196,11 @@
    "source": [
     "The output of `simulate` is an `MPS` object encoding the output state of the circuit. Currently we support two basic operations on `MPS` objects: obtaining amplitudes of computational states and calculating inner products with other `MPS` objects. More functionality (including sampling from the measurement distribution of the state) will come in due course.\n",
     "\n",
-    "### Obtain amplitude from MPS\n",
+    "### Obtain an amplitude from an MPS\n",
     "\n",
     "Let's first see how to get the amplitude of the state `|10100>` from the output of the previous circuit.\n",
     "\n",
-    "**NOTE**: whenever you wish to do calculations on an `MPS` object you must include these within a `with mps.init_cutensornet():` block; this will initialise the cuTensorNetwork library for you, and destroy its handles at the end of the `with` block."
+    "**NOTE**: whenever you wish to do calculations on an `MPS` object you must include these within a `with CuTensorNetHandle() as libhandle:` block; this will initialise the cuTensorNetwork library for you, and destroy its handles at the end of the `with` block. You will need to pass the `libhandle` to the `MPS` object via the `set_libhandle` method."
    ]
   },
   {
@@ -218,7 +219,8 @@
    ],
    "source": [
     "state = int('10100', 2)\n",
-    "with my_mps.init_cutensornet():\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    my_mps.set_libhandle(libhandle)\n",
     "    amplitude = get_amplitude(my_mps, state)\n",
     "print(amplitude)"
    ]
@@ -228,7 +230,7 @@
    "id": "35adb1f4-7615-4b03-b4a9-2e27d791ce6e",
    "metadata": {},
    "source": [
-    "Since this is a very small circuit, we can use `pytket`'s state vector simulator capabilities to check that the state is correct by checking the amplitude of each of the computational states."
+    "Since this is a very small circuit, we can use `pytket`'s state vector simulator capabilities to verify that the state is correct by checking the amplitude of each of the computational states."
    ]
   },
   {
@@ -251,7 +253,8 @@
     "n_qubits = len(my_circ.qubits)\n",
     "\n",
     "correct_amplitude = [False] * (2**n_qubits)\n",
-    "with my_mps.init_cutensornet():\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    my_mps.set_libhandle(libhandle)\n",
     "    for i in range(2**n_qubits):\n",
     "        correct_amplitude[i] = np.isclose(state_vector[i], get_amplitude(my_mps, i))\n",
     "\n",
@@ -285,7 +288,8 @@
     }
    ],
    "source": [
-    "with my_mps.init_cutensornet():\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    my_mps.set_libhandle(libhandle)\n",
     "    norm_sq = my_mps.vdot(my_mps)\n",
     "\n",
     "print(\"As expected, the squared norm of a state is 1\")\n",
@@ -342,7 +346,8 @@
     }
    ],
    "source": [
-    "with my_mps.init_cutensornet():\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    my_mps.set_libhandle(libhandle)\n",
     "    inner_product = my_mps.vdot(other_mps)\n",
     "    \n",
     "my_state = my_circ.get_statevector()\n",
@@ -393,7 +398,7 @@
        "\n",
        "\n",
        "\n",
-       "    &lt;div id=&#34;circuit-display-vue-container-50ee68de-7252-4b0e-9f46-5e4c6444f5d3&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-3f4e410b-6d42-4372-b0f0-09915a57f9e7&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
        "        &lt;div style=&#34;display: none&#34;&gt;\n",
        "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;ZZPhase&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.8&#34;], &#34;type&#34;: &#34;Ry&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.7&#34;], &#34;type&#34;: &#34;XXPhase&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.1&#34;, &#34;0.2&#34;, &#34;0.4&#34;], &#34;type&#34;: &#34;TK2&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]], [[&#34;q&#34;, [3]], [&#34;q&#34;, [3]]], [[&#34;q&#34;, [4]], [&#34;q&#34;, [4]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [3]], [&#34;q&#34;, [4]]]}&lt;/div&gt;\n",
        "        &lt;/div&gt;\n",
@@ -403,7 +408,7 @@
        "        &gt;&lt;/circuit-display-container&gt;\n",
        "    &lt;/div&gt;\n",
        "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
-       "      const circuitRendererUid = &#34;50ee68de-7252-4b0e-9f46-5e4c6444f5d3&#34;;\n",
+       "      const circuitRendererUid = &#34;3f4e410b-6d42-4372-b0f0-09915a57f9e7&#34;;\n",
        "      const displayOptions = JSON.parse(&#39;{}&#39;);\n",
        "\n",
        "      // Script to initialise the circuit renderer app\n",
@@ -520,7 +525,7 @@
        "\n",
        "\n",
        "\n",
-       "    &lt;div id=&#34;circuit-display-vue-container-38f0b1d7-fddf-49e7-854e-f091ee502de2&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-23b08f17-b76b-4557-8bcd-fe54b43aad79&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
        "        &lt;div style=&#34;display: none&#34;&gt;\n",
        "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.8&#34;], &#34;type&#34;: &#34;Ry&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [0]], [&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;SWAP&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [4]], [&#34;node&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [2]], [&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;ZZPhase&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [1]], [&#34;node&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [3]], [&#34;node&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.7&#34;], &#34;type&#34;: &#34;XXPhase&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [3]], [&#34;node&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;SWAP&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [2]], [&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;SWAP&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [1]], [&#34;node&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.1&#34;, &#34;0.2&#34;, &#34;0.4&#34;], &#34;type&#34;: &#34;TK2&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;node&#34;, [0]], [&#34;node&#34;, [0]]], [[&#34;node&#34;, [1]], [&#34;node&#34;, [1]]], [[&#34;node&#34;, [2]], [&#34;node&#34;, [2]]], [[&#34;node&#34;, [3]], [&#34;node&#34;, [3]]], [[&#34;node&#34;, [4]], [&#34;node&#34;, [4]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;node&#34;, [0]], [&#34;node&#34;, [1]], [&#34;node&#34;, [2]], [&#34;node&#34;, [3]], [&#34;node&#34;, [4]]]}&lt;/div&gt;\n",
        "        &lt;/div&gt;\n",
@@ -530,7 +535,7 @@
        "        &gt;&lt;/circuit-display-container&gt;\n",
        "    &lt;/div&gt;\n",
        "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
-       "      const circuitRendererUid = &#34;38f0b1d7-fddf-49e7-854e-f091ee502de2&#34;;\n",
+       "      const circuitRendererUid = &#34;23b08f17-b76b-4557-8bcd-fe54b43aad79&#34;;\n",
        "      const displayOptions = JSON.parse(&#39;{}&#39;);\n",
        "\n",
        "      // Script to initialise the circuit renderer app\n",
@@ -615,7 +620,8 @@
     "prep_mps = simulate(prep_circ, ContractionAlg.MPSxGate)\n",
     "\n",
     "print(\"Did simulation succeed?\")\n",
-    "with prep_mps.init_cutensornet():\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    prep_mps.set_libhandle(libhandle)\n",
     "    print(prep_mps.is_valid())"
    ]
   },
@@ -694,10 +700,10 @@
      "output_type": "stream",
      "text": [
       "Time taken by approximate contraction with bound chi:\n",
-      "1.77 seconds\n",
+      "1.66 seconds\n",
       "\n",
       "Lower bound of the fidelity:\n",
-      "0.4083\n"
+      "0.4776\n"
      ]
     }
    ],
@@ -730,10 +736,10 @@
      "output_type": "stream",
      "text": [
       "Time taken by approximate contraction with fixed truncation fidelity:\n",
-      "2.11 seconds\n",
+      "1.72 seconds\n",
       "\n",
       "Lower bound of the fidelity:\n",
-      "0.4428\n"
+      "0.4596\n"
      ]
     }
    ],
@@ -784,8 +790,8 @@
      "output_type": "stream",
      "text": [
       "MPSxGate\n",
-      "\tTime taken: 1.29 seconds\n",
-      "\tLower bound of the fidelity: 0.4069\n"
+      "\tTime taken: 1.11 seconds\n",
+      "\tLower bound of the fidelity: 0.4776\n"
      ]
     }
    ],
@@ -809,8 +815,8 @@
      "output_type": "stream",
      "text": [
       "MPSxMPO, default parameters\n",
-      "\tTime taken: 11.97 seconds\n",
-      "\tLower bound of the fidelity: 0.4486\n"
+      "\tTime taken: 9.24 seconds\n",
+      "\tLower bound of the fidelity: 0.523\n"
      ]
     }
    ],
@@ -834,8 +840,8 @@
      "output_type": "stream",
      "text": [
       "MPSxMPO, custom parameters\n",
-      "\tTime taken: 14.11 seconds\n",
-      "\tLower bound of the fidelity: 0.5959\n"
+      "\tTime taken: 10.61 seconds\n",
+      "\tLower bound of the fidelity: 0.648\n"
      ]
     }
    ],

--- a/pytket/extensions/cutensornet/mps/__init__.py
+++ b/pytket/extensions/cutensornet/mps/__init__.py
@@ -18,6 +18,7 @@ https://github.com/CQCL/pytket-cutensornet.
 """
 
 from .mps import (
+    CuTensorNetHandle,
     Handle,
     Bond,
     DirectionMPS,

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -136,7 +136,7 @@ class Tensor:
             The handle to the tensor descriptor.
 
         Raises:
-            RuntimeError: If ``lib`` is no longer in scope.
+            RuntimeError: If ``libhandle`` is no longer in scope.
             TypeError: If the type of the tensor is not supported. Supported types are
                 ``np.float32``, ``np.float64``, ``np.complex64`` and ``np.complex128``.
         """
@@ -267,7 +267,7 @@ class MPS:
         if chi is not None and truncation_fidelity is not None:
             raise ValueError("Cannot fix both chi and truncation_fidelity.")
         if chi is None:
-            chi = 2 ** (len(qubits) // 2)
+            chi = max(2 ** (len(qubits) // 2), 2)
         if truncation_fidelity is None:
             truncation_fidelity = 1
 
@@ -769,8 +769,9 @@ class MPS:
         self._flush()
 
         # Create a dummy object
-        new_mps = MPS(qubits=[], chi=self.chi, device_id=self.get_device_id())
+        new_mps = MPS(self._lib, qubits=[])
         # Copy all data
+        new_mps.chi = self.chi
         new_mps.truncation_fidelity = self.truncation_fidelity
         new_mps.fidelity = self.fidelity
         new_mps.tensors = [t.copy() for t in self.tensors]

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -46,25 +46,21 @@ class DirectionMPS(Enum):
 
 
 class CuTensorNetHandle:
-    """Context manager for the cuTensorNet library handle.
+    """Initialise the cuTensorNet library with automatic workspace memory
+    management.
+
+    Note:
+        Always use as ``with CuTensorNetHandle() as libhandle:`` so that cuTensorNet
+        handles are automatically destroyed at the end of execution.
 
     Attributes:
-        handle: The cuTensorNet library handle.
-        device_id: The ID of the device (GPU) where cuTensorNet is initialised.
+        handle (int): The cuTensorNet library handle created by this initialisation.
+        device_id (int): The ID of the device (GPU) where cuTensorNet is initialised.
+            If not provided, defaults to ``cp.cuda.Device()``.
     """
 
     def __init__(self, device_id: Optional[int] = None):
-        """Initialise the cuTensorNet library with automatic workspace memory
-        management allocation.
 
-        Note:
-            Always use as ``with CuTensorNetHandle() as libhandle:`` so that cuTensorNet
-            handles are automatically destroyed at the end of execution.
-
-        Args:
-            device_id: The ID of the device (GPU) where cuTensorNet is initialised.
-                If not provided, defaults to ``cp.cuda.Device()``.
-        """
         self.handle = cutn.create()
         self.device_id = device_id
         dev = cp.cuda.Device(device_id)

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -60,7 +60,6 @@ class CuTensorNetHandle:
     """
 
     def __init__(self, device_id: Optional[int] = None):
-
         self.handle = cutn.create()
         self.device_id = device_id
         self._is_destroyed = True

--- a/pytket/extensions/cutensornet/mps/mps_gate.py
+++ b/pytket/extensions/cutensornet/mps/mps_gate.py
@@ -167,14 +167,14 @@ class MPSxGate(MPS):
         S_d = cp.empty(new_dim, dtype=self._real_t)
 
         # Create tensor descriptors
-        T_desc = T.get_tensor_descriptor(self._libhandle)
-        L_desc = L.get_tensor_descriptor(self._libhandle)
-        R_desc = R.get_tensor_descriptor(self._libhandle)
+        T_desc = T.get_tensor_descriptor(self._lib)
+        L_desc = L.get_tensor_descriptor(self._lib)
+        R_desc = R.get_tensor_descriptor(self._lib)
 
         # Create SVDConfig with default configuration
-        svd_config = cutn.create_tensor_svd_config(self._libhandle)
+        svd_config = cutn.create_tensor_svd_config(self._lib.handle)
         # Create SVDInfo to record truncation information
-        svd_info = cutn.create_tensor_svd_info(self._libhandle)
+        svd_info = cutn.create_tensor_svd_info(self._lib.handle)
 
         if self.truncation_fidelity < 1:
             # Carry out SVD decomposition first with NO truncation
@@ -188,7 +188,7 @@ class MPSxGate(MPS):
             # including normalisation and contraction of S with L.
 
             cutn.tensor_svd(
-                self._libhandle,
+                self._lib.handle,
                 T_desc,
                 T.data.data.ptr,
                 L_desc,
@@ -288,7 +288,7 @@ class MPSxGate(MPS):
                 attr_dtype = cutn.tensor_svd_config_get_attribute_dtype(attr)
                 value = np.array([value], dtype=attr_dtype)
                 cutn.tensor_svd_config_set_attribute(
-                    self._libhandle,
+                    self._lib.handle,
                     svd_config,
                     attr,
                     value.ctypes.data,
@@ -297,7 +297,7 @@ class MPSxGate(MPS):
 
             # Apply SVD decomposition; truncation will be applied if needed
             cutn.tensor_svd(
-                self._libhandle,
+                self._lib.handle,
                 T_desc,
                 T.data.data.ptr,
                 L_desc,
@@ -318,7 +318,7 @@ class MPSxGate(MPS):
             )
             discarded_weight = np.empty(1, dtype=discarded_weight_dtype)
             cutn.tensor_svd_info_get_attribute(
-                self._libhandle,
+                self._lib.handle,
                 svd_info,
                 cutn.TensorSVDInfoAttribute.DISCARDED_WEIGHT,
                 discarded_weight.ctypes.data,

--- a/pytket/extensions/cutensornet/mps/mps_mpo.py
+++ b/pytket/extensions/cutensornet/mps/mps_mpo.py
@@ -84,7 +84,7 @@ class MPSxMPO(MPS):
                 Complex numbers are represented using two of such
                 ``float`` numbers. Default is ``np.float64``.
         """
-        super().__init__(qubits, chi, truncation_fidelity, float_precision, device_id)
+        super().__init__(libhandle, qubits, chi, truncation_fidelity, float_precision)
 
         # Initialise the MPO data structure. This will keep a list of the gates
         # batched for application to the MPS; all of them will be applied at
@@ -102,7 +102,7 @@ class MPSxMPO(MPS):
         # Initialise the MPS that we will use as first approximation of the
         # variational algorithm.
         self._aux_mps = MPSxGate(
-            qubits, chi, truncation_fidelity, float_precision, device_id
+            libhandle, qubits, chi, truncation_fidelity, float_precision
         )
 
         if k is None:

--- a/pytket/extensions/cutensornet/mps/mps_mpo.py
+++ b/pytket/extensions/cutensornet/mps/mps_mpo.py
@@ -14,7 +14,7 @@
 from __future__ import annotations  # type: ignore
 import warnings
 
-from typing import Optional, Any, Union
+from typing import Optional, Union
 
 import numpy as np  # type: ignore
 
@@ -236,12 +236,13 @@ class MPSxMPO(MPS):
         S_d = cp.empty(4, dtype=self._real_t)
 
         # Create tensor descriptors
-        G_desc = G.get_tensor_descriptor(self._libhandle)
-        L_desc = L.get_tensor_descriptor(self._libhandle)
-        R_desc = R.get_tensor_descriptor(self._libhandle)
+        assert self._lib is not None
+        G_desc = G.get_tensor_descriptor(self._lib)
+        L_desc = L.get_tensor_descriptor(self._lib)
+        R_desc = R.get_tensor_descriptor(self._lib)
 
         # Configure SVD parameters
-        svd_config = cutn.create_tensor_svd_config(self._libhandle)
+        svd_config = cutn.create_tensor_svd_config(self._lib.handle)
 
         svd_config_attributes = [
             # TensorSVDPartition.US asks that cuTensorNet automatically
@@ -257,17 +258,17 @@ class MPSxMPO(MPS):
             attr_dtype = cutn.tensor_svd_config_get_attribute_dtype(attr)
             value = np.array([value], dtype=attr_dtype)
             cutn.tensor_svd_config_set_attribute(
-                self._libhandle,
+                self._lib.handle,
                 svd_config,
                 attr,
                 value.ctypes.data,
                 value.dtype.itemsize,
             )
-        svd_info = cutn.create_tensor_svd_info(self._libhandle)
+        svd_info = cutn.create_tensor_svd_info(self._lib.handle)
 
         # Apply SVD decomposition; no truncation takes place
         cutn.tensor_svd(
-            self._libhandle,
+            self._lib.handle,
             G_desc,
             G.data.data.ptr,
             L_desc,

--- a/pytket/extensions/cutensornet/mps/mps_mpo.py
+++ b/pytket/extensions/cutensornet/mps/mps_mpo.py
@@ -113,8 +113,8 @@ class MPSxMPO(MPS):
         may use the same library handle.
 
         Raises:
-            RuntimeError: If the ``device_id`` of the ``libhandle`` does not match
-                the one of the ``MPS`` object.
+            RuntimeError: If the device (GPU) where ``libhandle`` was initialised
+                does not match the one where the tensors of the MPS are stored.
         """
         super().set_libhandle(libhandle)
         self._aux_mps.set_libhandle(libhandle)

--- a/pytket/extensions/cutensornet/mps/simulation.py
+++ b/pytket/extensions/cutensornet/mps/simulation.py
@@ -25,10 +25,14 @@ class ContractionAlg(Enum):
     MPSxMPO = 1
 
 
-def simulate(circuit: Circuit, algorithm: ContractionAlg, **kwargs: Any) -> MPS:
+def simulate(libhandle: CuTensorNetHandle, circuit: Circuit, algorithm: ContractionAlg, **kwargs: Any) -> MPS:
     """Simulate the given circuit and return the ``MPS`` representing the final state.
 
     Note:
+        A ``libhandle`` should be created via a ``with CuTensorNet() as libhandle:``
+        statement. The device where the MPS is stored will match the one specified
+        by the library handle.
+
         The input ``circuit`` must be composed of one-qubit and two-qubit gates only.
         Any gateset supported by ``pytket`` can be used.
 
@@ -37,6 +41,8 @@ def simulate(circuit: Circuit, algorithm: ContractionAlg, **kwargs: Any) -> MPS:
         circuit, consider using ``prepare_circuit()`` on it.
 
     Args:
+        libhandle: The cuTensorNet library handle that will be used to carry out
+            tensor operations on the MPS.
         circuit: The pytket circuit to be simulated.
         algorithm: Choose between the values of the ``ContractionAlg`` enum.
         **kwargs: Any argument accepted by the initialisers of the chosen
@@ -50,33 +56,30 @@ def simulate(circuit: Circuit, algorithm: ContractionAlg, **kwargs: Any) -> MPS:
     chi = kwargs.get("chi", None)
     truncation_fidelity = kwargs.get("truncation_fidelity", None)
     float_precision = kwargs.get("float_precision", None)
-    device_id = kwargs.get("device_id", None)
 
     if algorithm == ContractionAlg.MPSxGate:
         mps = MPSxGate(  # type: ignore
-            circuit.qubits, chi, truncation_fidelity, float_precision, device_id
+            libhandle, circuit.qubits, chi, truncation_fidelity, float_precision
         )
     elif algorithm == ContractionAlg.MPSxMPO:
         k = kwargs.get("k", None)
         optim_delta = kwargs.get("optim_delta", None)
         mps = MPSxMPO(  # type: ignore
+            libhandle,
             circuit.qubits,
             chi,
             truncation_fidelity,
             k,
             optim_delta,
             float_precision,
-            device_id,
         )
 
     # Sort the gates so there isn't much overhead from canonicalising back and forth.
     sorted_gates = _get_sorted_gates(circuit)
 
     # Apply the gates
-    with CuTensorNetHandle() as libhandle:
-        mps.set_libhandle(libhandle)
-        for g in sorted_gates:
-            mps.apply_gate(g)
+    for g in sorted_gates:
+        mps.apply_gate(g)
 
     return mps
 
@@ -89,13 +92,16 @@ def get_amplitude(mps: MPS, state: int) -> complex:
         state: The integer whose bitstring describes the computational state.
             The qubits in the bitstring are ordered in increasing lexicographic order.
 
+    Raises:
+        RuntimeError: If the ``CuTensorNetHandle`` is out of scope.
+
     Returns:
         The amplitude of the computational state in the MPS.
     """
-    if mps._lib is None:
+    if mps._lib._is_destroyed:
         raise RuntimeError(
-            "Provide a valid cuTensorNet library handle to the MPS object.",
-            "See the documentation of set_libhandle and CuTensorNetHandle.",
+            "The cuTensorNet library handle is out of scope.",
+            "See the documentation of update_libhandle and CuTensorNetHandle.",
         )
 
     mps_qubits = list(mps.qubit_position.keys())

--- a/pytket/extensions/cutensornet/mps/simulation.py
+++ b/pytket/extensions/cutensornet/mps/simulation.py
@@ -25,7 +25,12 @@ class ContractionAlg(Enum):
     MPSxMPO = 1
 
 
-def simulate(libhandle: CuTensorNetHandle, circuit: Circuit, algorithm: ContractionAlg, **kwargs: Any) -> MPS:
+def simulate(
+    libhandle: CuTensorNetHandle,
+    circuit: Circuit,
+    algorithm: ContractionAlg,
+    **kwargs: Any
+) -> MPS:
     """Simulate the given circuit and return the ``MPS`` representing the final state.
 
     Note:
@@ -105,8 +110,7 @@ def get_amplitude(mps: MPS, state: int) -> complex:
         )
 
     mps_qubits = list(mps.qubit_position.keys())
-    bra_mps = MPSxGate(mps_qubits)
-    bra_mps._lib = mps._lib
+    bra_mps = MPSxGate(mps._lib, mps_qubits)
 
     ilo_qubits = sorted(mps_qubits)
     for i, q in enumerate(ilo_qubits):

--- a/pytket/extensions/cutensornet/mps/simulation.py
+++ b/pytket/extensions/cutensornet/mps/simulation.py
@@ -9,7 +9,7 @@ from pytket.architecture import Architecture  # type: ignore
 from pytket.passes import DefaultMappingPass  # type: ignore
 from pytket.predicates import CompilationUnit  # type: ignore
 
-from .mps import MPS
+from .mps import CuTensorNetHandle, MPS
 from .mps_gate import MPSxGate
 from .mps_mpo import MPSxMPO
 
@@ -73,7 +73,8 @@ def simulate(circuit: Circuit, algorithm: ContractionAlg, **kwargs: Any) -> MPS:
     sorted_gates = _get_sorted_gates(circuit)
 
     # Apply the gates
-    with mps.init_cutensornet():
+    with CuTensorNetHandle() as libhandle:
+        mps.set_libhandle(libhandle)
         for g in sorted_gates:
             mps.apply_gate(g)
 

--- a/pytket/extensions/cutensornet/mps/simulation.py
+++ b/pytket/extensions/cutensornet/mps/simulation.py
@@ -93,7 +93,10 @@ def get_amplitude(mps: MPS, state: int) -> complex:
         The amplitude of the computational state in the MPS.
     """
     if mps._lib is None:
-        raise RuntimeError("Must be called inside a with mps.init_cutensornet() block.")
+        raise RuntimeError(
+            "Provide a valid cuTensorNet library handle to the MPS object.",
+            "See the documentation of set_libhandle and CuTensorNetHandle.",
+        )
 
     mps_qubits = list(mps.qubit_position.keys())
     bra_mps = MPSxGate(mps_qubits)

--- a/pytket/extensions/cutensornet/mps/simulation.py
+++ b/pytket/extensions/cutensornet/mps/simulation.py
@@ -92,12 +92,12 @@ def get_amplitude(mps: MPS, state: int) -> complex:
     Returns:
         The amplitude of the computational state in the MPS.
     """
-    if mps._libhandle is None:
+    if mps._lib is None:
         raise RuntimeError("Must be called inside a with mps.init_cutensornet() block.")
 
     mps_qubits = list(mps.qubit_position.keys())
     bra_mps = MPSxGate(mps_qubits)
-    bra_mps._libhandle = mps._libhandle
+    bra_mps._lib = mps._lib
 
     ilo_qubits = sorted(mps_qubits)
     for i, q in enumerate(ilo_qubits):

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -8,6 +8,7 @@ import numpy as np  # type: ignore
 
 from pytket.circuit import Circuit  # type: ignore
 from pytket.extensions.cutensornet.mps import (
+    CuTensorNetHandle,
     Tensor,
     MPSxGate,
     MPSxMPO,
@@ -18,15 +19,42 @@ from pytket.extensions.cutensornet.mps import (
 )
 
 
+def test_libhandle_manager() -> None:
+    circ = Circuit(5)
+    mps = MPS(qubits=circ.qubits)
+
+    # Catch exception due to no library handle initialised
+    exception_caught = False
+    try
+        mps.is_valid()
+    except RuntimeException:
+        exception_caught = True
+    assert exception_caught
+
+    # Proper use of library handle
+    with CuTensorNetHandle as libhandle:
+        mps.set_libhandle(libhandle)
+        assert mps.is_valid()
+
+    # Catch exception due to library handle out of scope
+    exception_caught = False
+    try
+        mps.is_valid()
+    except RuntimeException:
+        exception_caught = True
+    assert exception_caught
+
+
 def test_init() -> None:
     circ = Circuit(5)
 
     mps_gate = MPSxGate(qubits=circ.qubits)
-    with mps_gate.init_cutensornet():
-        assert mps_gate.is_valid()
-
     mps_mpo = MPSxMPO(qubits=circ.qubits)
-    with mps_mpo.init_cutensornet():
+
+    with CuTensorNetHandle() as libhandle:
+        mps_gate.set_libhandle(libhandle)
+        assert mps_gate.is_valid()
+        mps_mpo.set_libhandle(libhandle)
         assert mps_mpo.is_valid()
 
 
@@ -35,7 +63,8 @@ def test_canonicalise() -> None:
     circ = Circuit(5)
 
     mps_gate = MPSxGate(qubits=circ.qubits)
-    with mps_gate.init_cutensornet():
+    with CuTensorNetHandle() as libhandle:
+        mps_gate.set_libhandle(libhandle)
         # Fill up the tensors with random entries
 
         # Leftmost tensor
@@ -137,7 +166,8 @@ def test_exact_circ_sim(circuit: Circuit, algorithm: ContractionAlg) -> None:
     state = prep_circ.get_statevector()
 
     mps = simulate(prep_circ, algorithm)
-    with mps.init_cutensornet():
+    with CuTensorNetHandle() as libhandle:
+        mps.set_libhandle(libhandle)
         assert mps.is_valid()
         # Check that there was no approximation
         assert np.isclose(mps.fidelity, 1.0, atol=mps._atol)
@@ -186,7 +216,8 @@ def test_exact_circ_sim(circuit: Circuit, algorithm: ContractionAlg) -> None:
 def test_approx_circ_sim_gate_fid(circuit: Circuit, algorithm: ContractionAlg) -> None:
     prep_circ, _ = prepare_circuit(circuit)
     mps = simulate(prep_circ, algorithm, truncation_fidelity=0.99)
-    with mps.init_cutensornet():
+    with CuTensorNetHandle() as libhandle:
+        mps.set_libhandle(libhandle)
         assert mps.is_valid()
         # Check that overlap is 1
         assert np.isclose(mps.vdot(mps), 1.0, atol=mps._atol)
@@ -225,7 +256,8 @@ def test_approx_circ_sim_gate_fid(circuit: Circuit, algorithm: ContractionAlg) -
 def test_approx_circ_sim_chi(circuit: Circuit, algorithm: ContractionAlg) -> None:
     prep_circ, _ = prepare_circuit(circuit)
     mps = simulate(prep_circ, algorithm, chi=4)
-    with mps.init_cutensornet():
+    with CuTensorNetHandle() as libhandle:
+        mps.set_libhandle(libhandle)
         assert mps.is_valid()
         # Check that overlap is 1
         assert np.isclose(mps.vdot(mps), 1.0, atol=mps._atol)
@@ -261,25 +293,26 @@ def test_float_point_options(
 ) -> None:
     prep_circ, _ = prepare_circuit(circuit)
 
-    # Exact
-    mps = simulate(prep_circ, algorithm, float_precision=fp_precision)
-    with mps.init_cutensornet():
+    with CuTensorNetHandle() as libhandle:
+        # Exact
+        mps = simulate(prep_circ, algorithm, float_precision=fp_precision)
+        mps.set_libhandle(libhandle)
         assert mps.is_valid()
         # Check that overlap is 1
         assert np.isclose(mps.vdot(mps), 1.0, atol=mps._atol)
 
-    # Approximate, bound truncation fidelity
-    mps = simulate(
-        prep_circ, algorithm, truncation_fidelity=0.99, float_precision=fp_precision
-    )
-    with mps.init_cutensornet():
+        # Approximate, bound truncation fidelity
+        mps = simulate(
+            prep_circ, algorithm, truncation_fidelity=0.99, float_precision=fp_precision
+        )
+        mps.set_libhandle(libhandle)
         assert mps.is_valid()
         # Check that overlap is 1
         assert np.isclose(mps.vdot(mps), 1.0, atol=mps._atol)
 
-    # Approximate, bound chi
-    mps = simulate(prep_circ, algorithm, chi=4, float_precision=fp_precision)
-    with mps.init_cutensornet():
+        # Approximate, bound chi
+        mps = simulate(prep_circ, algorithm, chi=4, float_precision=fp_precision)
+        mps.set_libhandle(libhandle)
         assert mps.is_valid()
         # Check that overlap is 1
         assert np.isclose(mps.vdot(mps), 1.0, atol=mps._atol)
@@ -294,36 +327,33 @@ def test_float_point_options(
 def test_circ_approx_explicit(circuit: Circuit) -> None:
     random.seed(1)
 
-    # Finite gate fidelity
-    # Check for MPSxGate
-    mps_gate = simulate(circuit, ContractionAlg.MPSxGate, truncation_fidelity=0.99)
-    assert np.isclose(mps_gate.fidelity, 0.4, atol=1e-1)
-
-    with mps_gate.init_cutensornet():
+    with CuTensorNetHandle() as libhandle:
+        # Finite gate fidelity
+        # Check for MPSxGate
+        mps_gate = simulate(circuit, ContractionAlg.MPSxGate, truncation_fidelity=0.99)
+        mps_gate.set_libhandle(libhandle)
+        assert np.isclose(mps_gate.fidelity, 0.4, atol=1e-1)
         assert mps_gate.is_valid()
         assert np.isclose(mps_gate.vdot(mps_gate), 1.0, atol=mps_gate._atol)
 
-    # Check for MPSxMPO
-    mps_mpo = simulate(circuit, ContractionAlg.MPSxMPO, truncation_fidelity=0.99)
-    assert np.isclose(mps_mpo.fidelity, 0.6, atol=1e-1)
-
-    with mps_mpo.init_cutensornet():
+        # Check for MPSxMPO
+        mps_mpo = simulate(circuit, ContractionAlg.MPSxMPO, truncation_fidelity=0.99)
+        mps_mpo.set_libhandle(libhandle)
+        assert np.isclose(mps_mpo.fidelity, 0.6, atol=1e-1)
         assert mps_mpo.is_valid()
         assert np.isclose(mps_mpo.vdot(mps_mpo), 1.0, atol=mps_mpo._atol)
 
-    # Fixed virtual bond dimension
-    # Check for MPSxGate
-    mps_gate = simulate(circuit, ContractionAlg.MPSxGate, chi=8)
-    assert np.isclose(mps_gate.fidelity, 0.05, atol=1e-2)
-
-    with mps_gate.init_cutensornet():
+        # Fixed virtual bond dimension
+        # Check for MPSxGate
+        mps_gate = simulate(circuit, ContractionAlg.MPSxGate, chi=8)
+        mps_gate.set_libhandle(libhandle)
+        assert np.isclose(mps_gate.fidelity, 0.05, atol=1e-2)
         assert mps_gate.is_valid()
         assert np.isclose(mps_gate.vdot(mps_gate), 1.0, atol=mps_gate._atol)
 
-    # Check for MPSxMPO
-    mps_mpo = simulate(circuit, ContractionAlg.MPSxMPO, chi=8)
-    assert np.isclose(mps_mpo.fidelity, 0.09, atol=1e-2)
-
-    with mps_mpo.init_cutensornet():
+        # Check for MPSxMPO
+        mps_mpo = simulate(circuit, ContractionAlg.MPSxMPO, chi=8)
+        mps_mpo.set_libhandle(libhandle)
+        assert np.isclose(mps_mpo.fidelity, 0.09, atol=1e-2)
         assert mps_mpo.is_valid()
         assert np.isclose(mps_mpo.vdot(mps_mpo), 1.0, atol=mps_mpo._atol)

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -10,6 +10,7 @@ from pytket.circuit import Circuit  # type: ignore
 from pytket.extensions.cutensornet.mps import (
     CuTensorNetHandle,
     Tensor,
+    MPS,
     MPSxGate,
     MPSxMPO,
     simulate,
@@ -25,22 +26,22 @@ def test_libhandle_manager() -> None:
 
     # Catch exception due to no library handle initialised
     exception_caught = False
-    try
-        mps.is_valid()
-    except RuntimeException:
+    try:
+        mps.vdot(mps)
+    except RuntimeError:
         exception_caught = True
     assert exception_caught
 
     # Proper use of library handle
-    with CuTensorNetHandle as libhandle:
+    with CuTensorNetHandle() as libhandle:
         mps.set_libhandle(libhandle)
-        assert mps.is_valid()
+        assert np.isclose(mps.vdot(mps), 1, atol=mps._atol)
 
     # Catch exception due to library handle out of scope
     exception_caught = False
-    try
-        mps.is_valid()
-    except RuntimeException:
+    try:
+        mps.vdot(mps)
+    except RuntimeError:
         exception_caught = True
     assert exception_caught
 

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -29,12 +29,8 @@ def test_libhandle_manager() -> None:
         assert np.isclose(mps.vdot(mps), 1, atol=mps._atol)
 
     # Catch exception due to library handle out of scope
-    exception_caught = False
-    try:
+    with pytest.raises(RuntimeError):
         mps.vdot(mps)
-    except RuntimeError:
-        exception_caught = True
-    assert exception_caught
 
 
 def test_init() -> None:
@@ -287,14 +283,20 @@ def test_float_point_options(
 
         # Approximate, bound truncation fidelity
         mps = simulate(
-            libhandle, prep_circ, algorithm, truncation_fidelity=0.99, float_precision=fp_precision
+            libhandle,
+            prep_circ,
+            algorithm,
+            truncation_fidelity=0.99,
+            float_precision=fp_precision,
         )
         assert mps.is_valid()
         # Check that overlap is 1
         assert np.isclose(mps.vdot(mps), 1.0, atol=mps._atol)
 
         # Approximate, bound chi
-        mps = simulate(libhandle, prep_circ, algorithm, chi=4, float_precision=fp_precision)
+        mps = simulate(
+            libhandle, prep_circ, algorithm, chi=4, float_precision=fp_precision
+        )
         assert mps.is_valid()
         # Check that overlap is 1
         assert np.isclose(mps.vdot(mps), 1.0, atol=mps._atol)
@@ -312,13 +314,17 @@ def test_circ_approx_explicit(circuit: Circuit) -> None:
     with CuTensorNetHandle() as libhandle:
         # Finite gate fidelity
         # Check for MPSxGate
-        mps_gate = simulate(libhandle, circuit, ContractionAlg.MPSxGate, truncation_fidelity=0.99)
+        mps_gate = simulate(
+            libhandle, circuit, ContractionAlg.MPSxGate, truncation_fidelity=0.99
+        )
         assert np.isclose(mps_gate.fidelity, 0.4, atol=1e-1)
         assert mps_gate.is_valid()
         assert np.isclose(mps_gate.vdot(mps_gate), 1.0, atol=mps_gate._atol)
 
         # Check for MPSxMPO
-        mps_mpo = simulate(libhandle, circuit, ContractionAlg.MPSxMPO, truncation_fidelity=0.99)
+        mps_mpo = simulate(
+            libhandle, circuit, ContractionAlg.MPSxMPO, truncation_fidelity=0.99
+        )
         assert np.isclose(mps_mpo.fidelity, 0.6, atol=1e-1)
         assert mps_mpo.is_valid()
         assert np.isclose(mps_mpo.vdot(mps_mpo), 1.0, atol=mps_mpo._atol)


### PR DESCRIPTION
Refactoring the context manager for the handle of `cuTensorNet` so that multiple MPS may use the same one.

There's also a new `get_device_id` method in `MPS` to retrieve the _actual_ device where the MPS data is allocated. I previously kept a `_device_id` attribute, but that only kept track of where the `MPS` was originally initialised.