### PR TITLE
Refactor/decompose primitives

### DIFF
--- a/docs/modules/mps.rst
+++ b/docs/modules/mps.rst
@@ -24,9 +24,7 @@ Classes
     .. automethod:: apply_gate
     .. automethod:: vdot
     .. automethod:: canonicalise
-    .. automethod:: get_virtual_bonds
     .. automethod:: get_virtual_dimensions
-    .. automethod:: get_physical_bond
     .. automethod:: get_physical_dimension
     .. automethod:: get_device_id
     .. automethod:: is_valid
@@ -45,13 +43,6 @@ Classes
     .. automethod:: __init__
 
 .. autoclass:: pytket.extensions.cutensornet.mps.CuTensorNetHandle
-
-.. autoclass:: pytket.extensions.cutensornet.mps.Tensor()
-
-    .. automethod:: __init__
-    .. automethod:: get_bond_dimension
-    .. automethod:: get_tensor_descriptor
-    .. automethod:: copy
 
 
 Miscellaneous

--- a/pytket/extensions/cutensornet/mps/__init__.py
+++ b/pytket/extensions/cutensornet/mps/__init__.py
@@ -19,9 +19,8 @@ https://github.com/CQCL/pytket-cutensornet.
 
 from .mps import (
     CuTensorNetHandle,
-    Handle,
-    Bond,
     DirectionMPS,
+    Handle,
     Tensor,
     MPS,
 )

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -35,7 +35,10 @@ from pytket.circuit import Command, Op, Qubit  # type: ignore
 # base python) has some meaningful type name.
 Handle = int
 # An alias for the CuPy type used for tensors
-Tensor = cp.ndarray
+try:
+    Tensor = cp.ndarray
+except NameError:
+    Tensor = Any
 
 
 class DirectionMPS(Enum):

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -62,7 +62,11 @@ class CuTensorNetHandle:
     def __init__(self, device_id: Optional[int] = None):
         self.handle = cutn.create()
         self._is_destroyed = False
-        dev = cp.cuda.Device(device_id)
+
+        # Make sure CuPy uses the specified device
+        cp.cuda.Device(device_id).use()
+
+        dev = cp.cuda.Device()
         self.device_id = int(dev)
 
         if cp.cuda.runtime.runtimeGetVersion() < 11020:
@@ -292,8 +296,6 @@ class MPS:
 
         self._stream: cp.cuda.Stream = cp.cuda.get_current_stream()
         self._lib = libhandle
-        # Make sure CuPy uses the specified device
-        cp.cuda.Device(libhandle.device_id).use()
 
         #######################################
         # Initialise the MPS with a |0> state #

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -41,10 +41,12 @@ Bond = int
 
 def _bonds_to_subscripts(in_ids: list[list[Bond]], out_ids: list[list[Bond]]) -> str:
     """Convert the collection of bond lists to string subscript form as in cuQuantum.
+
     That is, each element in the list ``in_ids`` corresponds to the bonds of an input
     tensor; similarly for ``out_ids``. Convert these to a string of characters where
     the different tensors are separated by commas and input is separated from output
-    by ``->``.
+    by ``->``. For instance, if ``in_ids`` is ``[[2,1,4,5]]`` and ``out_ids`` is
+    ``[[4,-1,2],[1,-1,5]]`` the output would be ``bacd->ceb,aed``.
 
     Notes:
         The assignment of bond ID to character may not be consistent accross calls to
@@ -487,11 +489,9 @@ class MPS:
 
         if form == DirectionMPS.LEFT:
             next_pos = pos + 1
-            gauge_bond = pos + 1
             gauge_T_index = 0
         elif form == DirectionMPS.RIGHT:
             next_pos = pos - 1
-            gauge_bond = pos
             gauge_T_index = -2
         else:
             raise ValueError("Argument form must be a value in DirectionMPS.")
@@ -499,9 +499,7 @@ class MPS:
         # Gather the details from the MPS tensor at this position
         T = self.tensors[pos]
         p_bond = self.get_physical_bond(pos)
-        p_dim = self.get_physical_dimension(pos)
         v_bonds = self.get_virtual_bonds(pos)
-        v_dims = self.get_virtual_dimensions(pos)
 
         # Infer the bond IDs of the Q and R tensors
         if pos == 0:

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -34,41 +34,8 @@ from pytket.circuit import Command, Op, Qubit  # type: ignore
 # An alias so that `intptr_t` from CuQuantum's API (which is not available in
 # base python) has some meaningful type name.
 Handle = int
-# An alias for the type of the unique identifiers of each of the bonds
-# of the MPS.
-Bond = int
-
-
-def _bonds_to_subscripts(in_ids: list[list[Bond]], out_ids: list[list[Bond]]) -> str:
-    """Convert the collection of bond lists to string subscript form as in cuQuantum.
-
-    That is, each element in the list ``in_ids`` corresponds to the bonds of an input
-    tensor; similarly for ``out_ids``. Convert these to a string of characters where
-    the different tensors are separated by commas and input is separated from output
-    by ``->``. For instance, if ``in_ids`` is ``[[2,1,4,5]]`` and ``out_ids`` is
-    ``[[4,-1,2],[1,-1,5]]`` the output would be ``bacd->ceb,aed``.
-
-    Notes:
-        The assignment of bond ID to character may not be consistent accross calls to
-        this function.
-    """
-
-    id_set = {b_id for bond_list in (in_ids + out_ids) for b_id in bond_list}
-    a_int = ord("a")
-    bond_char_map: dict[Bond, str] = dict()
-    for i, bond_id in enumerate(id_set):
-        bond_char_map[bond_id] = chr(a_int + i)
-
-    string = []
-    for bond_list in in_ids:
-        string += [bond_char_map[b_id] for b_id in bond_list] + [","]
-    string.pop()
-    string += ["->"]
-    for bond_list in out_ids:
-        string += [bond_char_map[b_id] for b_id in bond_list] + [","]
-    string.pop()
-
-    return "".join(string)
+# An alias for the CuPy type used for tensors
+Tensor = cp.ndarray
 
 
 class DirectionMPS(Enum):
@@ -110,109 +77,6 @@ class CuTensorNetHandle:
         self._is_destroyed = True
 
 
-class Tensor:
-    """Class for the management of tensors via CuPy and cuTensorNet.
-
-    It abstracts away some of the low-level API of cuTensorNet.
-
-    Attributes:
-        data (cupy.ndarray): The entries of the tensor arranged in a CuPy ndarray.
-        bonds (list[Bond]): A list of IDs for each bond, matching the same order
-            as in ``self.data.shape`` (which provides the dimension of each).
-        canonical_form (Optional[DirectionMPS]): If in canonical form, indicate
-            which one; else None.
-    """
-
-    def __init__(self, data: cp.ndarray, bonds: list[Bond]):
-        """
-        Args:
-            data: The entries of the tensor arranged in a CuPy ndarray.
-            bonds: A list of IDs for each bond, matching the same order
-                as in ``self.data.shape`` (which provides the dimension of each).
-        """
-        self.data = data
-        self.bonds = bonds
-        self.canonical_form: Optional[DirectionMPS] = None
-
-    def get_tensor_descriptor(self, libhandle: CuTensorNetHandle) -> Handle:
-        """Return the cuTensorNet tensor descriptor.
-
-        Note:
-            The user is responsible of destroying the descriptor once
-            not in use (see ``cuquantum.cutensornet.destroy_tensor_descriptor``).
-
-        Args:
-            libhandle: The cuTensorNet library handle.
-
-        Returns:
-            The handle to the tensor descriptor.
-
-        Raises:
-            RuntimeError: If ``libhandle`` is no longer in scope.
-            TypeError: If the type of the tensor is not supported. Supported types are
-                ``np.float32``, ``np.float64``, ``np.complex64`` and ``np.complex128``.
-        """
-        if libhandle._is_destroyed:
-            raise RuntimeError("The library handle you passed is no longer in scope.")
-        if self.data.dtype == np.float32:
-            cq_dtype = cq.cudaDataType.CUDA_R_32F
-        elif self.data.dtype == np.float64:
-            cq_dtype = cq.cudaDataType.CUDA_R_64F
-        elif self.data.dtype == np.complex64:
-            cq_dtype = cq.cudaDataType.CUDA_C_32F
-        elif self.data.dtype == np.complex128:
-            cq_dtype = cq.cudaDataType.CUDA_C_64F
-        else:
-            raise TypeError(
-                f"The data type {self.data.dtype} of the tensor is not supported."
-            )
-
-        return cutn.create_tensor_descriptor(  # type: ignore
-            handle=libhandle.handle,
-            n_modes=len(self.data.shape),
-            extents=self.data.shape,
-            strides=self._get_cuquantum_strides(),
-            modes=self.bonds,
-            data_type=cq_dtype,
-        )
-
-    def _get_cuquantum_strides(self) -> list[int]:
-        """Return a list of the strides for each of the bonds.
-
-        Returns them in the same order as in ``self.bonds``.
-
-        Returns:
-            List of strides in cuQuantum format (#entries).
-        """
-        return [stride // self.data.itemsize for stride in self.data.strides]
-
-    def get_bond_dimension(self, bond: Bond) -> int:
-        """Given a bond ID, return that bond's dimension.
-
-        Args:
-            bond: The ID of the bond to be queried. If not in the tensor,
-                an exception is raised.
-
-        Returns:
-            The dimension of the bond.
-
-        Raises:
-            RuntimeError: If ``bond`` is not in a Tensor.
-        """
-        if bond not in self.bonds:
-            raise RuntimeError(f"Bond {bond} not in tensor with bonds: {self.bonds}.")
-        return int(self.data.shape[self.bonds.index(bond)])
-
-    def copy(self) -> Tensor:
-        """
-        Returns:
-            A deep copy of the Tensor.
-        """
-        other = Tensor(self.data.copy(), self.bonds.copy())
-        other.canonical_form = self.canonical_form
-        return other
-
-
 class MPS:
     """Represents a state as a Matrix Product State.
 
@@ -221,7 +85,12 @@ class MPS:
         truncation_fidelity (float): The target fidelity of SVD truncation.
         tensors (list[Tensor]): A list of tensors in the MPS; ``tensors[0]`` is
             the leftmost and ``tensors[len(self)-1]`` is the rightmost; ``tensors[i]``
-            and ``tensors[i+1]`` are connected in the MPS via a bond.
+            and ``tensors[i+1]`` are connected in the MPS via a bond. All of the
+            tensors are rank three, with the dimensions listed in ``.shape`` matching
+            the left, right and physical bonds, in that order.
+        canonical_form (dict[int, Optional[DirectionMPS]]): A dictionary mapping
+            positions to the canonical form direction of the corresponding tensor,
+            or ``None`` if it the tensor is not canonicalised.
         qubit_position (dict[pytket.circuit.Qubit, int]): A dictionary mapping circuit
             qubits to the position its tensor is at in the MPS.
         fidelity (float): A lower bound of the fidelity, obtained by multiplying
@@ -230,10 +99,6 @@ class MPS:
             states before and after truncation (assuming both are normalised).
     """
 
-    # Some (non-doc) comments on how bond identifiers are numbered:
-    # - The left virtual bond of the tensor `i` of the MPS has ID `i`.
-    # - The right virtual bond of the tensor `i` of the MPS has ID `i+1`.
-    # - The physical bond of the tensor `i` has ID `i+len(tensors)`.
     def __init__(
         self,
         libhandle: CuTensorNetHandle,
@@ -302,7 +167,6 @@ class MPS:
                 f"Value of float_precision must be in {allowed_precisions}."
             )
 
-        self._stream: cp.cuda.Stream = cp.cuda.get_current_stream()
         self._lib = libhandle
 
         #######################################
@@ -321,39 +185,24 @@ class MPS:
 
         self.qubit_position = {q: i for i, q in enumerate(qubits)}
 
-        # Create the first and last tensors (these have one fewer bond)
-        lr_shape = (1, 2)  # Initial virtual bond dim is 1; physical is 2
-        l_tensor = cp.empty(lr_shape, dtype=self._complex_t)
-        r_tensor = cp.empty(lr_shape, dtype=self._complex_t)
-        # Initialise each tensor to ket 0
-        l_tensor[0][0] = 1
-        l_tensor[0][1] = 0
-        r_tensor[0][0] = 1
-        r_tensor[0][1] = 0
-
         # Create the list of tensors
         self.tensors = []
-        # Append the leftmost tensor
-        self.tensors.append(Tensor(l_tensor, [1, n_tensors]))
 
-        # Append each of the tensors in between
+        # Append each of the tensors initialised in state |0>
         m_shape = (1, 1, 2)  # Two virtual bonds (dim=1) and one physical
-        for i in range(1, n_tensors - 1):
+        for i in range(n_tensors):
             m_tensor = cp.empty(m_shape, dtype=self._complex_t)
             # Initialise the tensor to ket 0
             m_tensor[0][0][0] = 1
             m_tensor[0][0][1] = 0
-            self.tensors.append(Tensor(m_tensor, [i, i + 1, i + n_tensors]))
-
-        # Append the rightmost tensor
-        self.tensors.append(Tensor(r_tensor, [n_tensors - 1, 2 * n_tensors - 1]))
+            self.tensors.append(m_tensor)
 
     def is_valid(self) -> bool:
         """Verify that the MPS object is valid.
 
         Specifically, verify that the MPS does not exceed the dimension limit ``chi`` of
-        the virtual bonds, that physical bonds have dimension 2 and that
-        the virtual bonds are connected in a line.
+        the virtual bonds, that physical bonds have dimension 2 and that all tensors
+        are rank three.
 
         Returns:
             False if a violation was detected or True otherwise.
@@ -366,23 +215,11 @@ class MPS:
         )
         phys_ok = all(self.get_physical_dimension(pos) == 2 for pos in range(len(self)))
         shape_ok = all(
-            len(tensor.data.shape) == len(tensor.bonds) and len(tensor.bonds) <= 3
+            len(tensor.shape) == 3
             for tensor in self.tensors
         )
 
-        # Check the leftmost tensor
-        v_bonds_ok = self.get_virtual_bonds(0)[0] == 1
-        # Check the middle tensors
-        for i in range(1, len(self) - 1):
-            v_bonds_ok = v_bonds_ok and (
-                self.get_virtual_bonds(i)[0] == i
-                and self.get_virtual_bonds(i)[1] == i + 1
-            )
-        # Check the rightmost tensor
-        i = len(self) - 1
-        v_bonds_ok = v_bonds_ok and self.get_virtual_bonds(i)[0] == i
-
-        return chi_ok and phys_ok and shape_ok and v_bonds_ok
+        return chi_ok and phys_ok and shape_ok
 
     def apply_gate(self, gate: Command) -> MPS:
         """Apply the gate to the MPS.
@@ -432,8 +269,8 @@ class MPS:
                 )
             self._apply_2q_gate((positions[0], positions[1]), gate.op)
             # The tensors will in general no longer be in canonical form.
-            self.tensors[positions[0]].canonical_form = None
-            self.tensors[positions[1]].canonical_form = None
+            self.canonical_form[positions[0]] = None
+            self.canonical_form[positions[1]] = None
 
         else:
             raise RuntimeError(
@@ -475,9 +312,8 @@ class MPS:
         Raises:
             ValueError: If ``form`` is not a value in ``DirectionMPS``.
             RuntimeError: If the ``CuTensorNetHandle`` is out of scope.
-            RuntimeError: If position and form don't match.
         """
-        if form == self.tensors[pos].canonical_form:
+        if form == self.canonical_form[pos]:
             # Tensor already in canonical form, nothing needs to be done
             return None
 
@@ -487,67 +323,51 @@ class MPS:
                 "See the documentation of update_libhandle and CuTensorNetHandle.",
             )
 
+        # Glossary of bond IDs used here:
+        # s -> shared virtual bond between T and Tnext
+        # v -> the other virtual bond of T
+        # V -> the other virtual bond of Tnext
+        # p -> physical bond of T
+        # P -> physical bond of Tnext
+
+        # Gather the details from the MPS tensors at this position
+        T = self.tensors[pos]
+
+        # Assign the bond IDs
         if form == DirectionMPS.LEFT:
             next_pos = pos + 1
-            gauge_T_index = 0
+            Tnext = self.tensors[next_pos]
+            T_bonds = "vsp"
+            Q_bonds = "vap"
+            R_bonds = "as"
+            Tnext_bonds = "sVP"
+            result_bonds = "aVP"
         elif form == DirectionMPS.RIGHT:
             next_pos = pos - 1
-            gauge_T_index = -2
+            Tnext = self.tensors[next_pos]
+            T_bonds = "svp"
+            Q_bonds = "avp"
+            R_bonds = "as"
+            Tnext_bonds = "VsP"
+            result_bonds = "VaP"
         else:
             raise ValueError("Argument form must be a value in DirectionMPS.")
 
-        # Gather the details from the MPS tensor at this position
-        T = self.tensors[pos]
-        p_bond = self.get_physical_bond(pos)
-        v_bonds = self.get_virtual_bonds(pos)
-
-        # Infer the bond IDs of the Q and R tensors
-        if pos == 0:
-            if form == DirectionMPS.RIGHT:
-                raise RuntimeError(
-                    "The leftmost tensor cannot be in right orthogonal form."
-                )
-            Q_bonds = [-1, p_bond]
-            R_bonds = [-1, v_bonds[0]]
-
-        elif pos == len(self) - 1:
-            if form == DirectionMPS.LEFT:
-                raise RuntimeError(
-                    "The rightmost tensor cannot be in left orthogonal form."
-                )
-            Q_bonds = [-1, p_bond]
-            R_bonds = [v_bonds[0], -1]
-
-        else:
-            if form == DirectionMPS.LEFT:
-                Q_bonds = [v_bonds[0], -1, p_bond]
-                R_bonds = [-1, v_bonds[1]]
-            elif form == DirectionMPS.RIGHT:
-                Q_bonds = [-1, v_bonds[1], p_bond]
-                R_bonds = [v_bonds[0], -1]
-
         # Apply QR decomposition
-        subscripts = _bonds_to_subscripts([T.bonds], [Q_bonds, R_bonds])
+        subscripts = T_bonds+"->"+Q_bonds+","+R_bonds
         options = {"handle": self._lib.handle, "device_id": self._lib.device_id}
-        Q_d, R_d = tensor.decompose(
-            subscripts, T.data, method=tensor.QRMethod(), options=options
+        Q, R = tensor.decompose(
+            subscripts, T, method=tensor.QRMethod(), options=options
         )
 
-        # Contract R into the tensor of the next position
-        Tnext_bonds = list(self.tensors[next_pos].bonds)
-        Tnext_bonds[gauge_T_index] = -1
-        Tnext_d = cq.contract(
-            R_d,
-            R_bonds,
-            self.tensors[next_pos].data,
-            self.tensors[next_pos].bonds,
-            Tnext_bonds,
-        )
+        # Contract R into Tnext
+        subscripts = R_bonds+","+Tnext_bonds+"->"+result_bonds
+        result = cq.contract(subscripts, R, Tnext)
 
         # Update self.tensors
-        self.tensors[pos].data = Q_d
+        self.tensors[pos] = Q
         self.tensors[pos].canonical_form = form
-        self.tensors[next_pos].data = Tnext_d
+        self.tensors[next_pos] = result
         self.tensors[next_pos].canonical_form = None
 
     def vdot(self, other: MPS) -> complex:
@@ -593,87 +413,35 @@ class MPS:
         # The two MPS will be contracted from left to right, storing the
         # ``partial_result`` tensor.
         partial_result = cq.contract(
-            self.tensors[0].data.conj(), [-1, 0], other.tensors[0].data, [1, 0], [-1, 1]
+            "LRp,lrp->Rr", self.tensors[0].conj(), other.tensors[0]
         )
         # Contract all tensors in the middle
         for pos in range(1, len(self) - 1):
             partial_result = cq.contract(
+                "Ll,LRp,lrp->Rr",
                 partial_result,
-                [-pos, pos],
-                self.tensors[pos].data.conj(),
-                [-pos, -(pos + 1), 0],
-                other.tensors[pos].data,
-                [pos, pos + 1, 0],
-                [-(pos + 1), pos + 1],
+                self.tensors[pos].conj(),
+                other.tensors[pos],
             )
         # Finally, contract the last tensor
         result = cq.contract(
+            "Ll,LRp,lrp->",  # R and r are dim 1, so they are omitted; scalar result
             partial_result,
-            [-(len(self) - 1), len(self) - 1],
-            self.tensors[-1].data.conj(),
-            [-(len(self) - 1), 0],
-            other.tensors[-1].data,
-            [len(self) - 1, 0],
-            [],  # No open bonds remain; this is just a scalar
+            self.tensors[-1].conj(),
+            other.tensors[-1],
         )
 
         return complex(result)
 
-    def get_virtual_bonds(self, position: int) -> list[Bond]:
-        """Returns the virtual bonds unique identifiers of tensor ``tensors[position]``.
-
-        Args:
-            position: A position in the MPS.
-
-        Returns:
-            A list with the ID of the virtual bonds of the tensor
-            in order from left to right.
-            If ``position`` is the first or last in the MPS, then the list
-            will only contain the corresponding virtual bond.
-
-        Raises:
-            RuntimeError: If ``position`` is out of bounds.
-        """
-        if position < 0 or position >= len(self):
-            raise RuntimeError(f"Position {position} is out of bounds.")
-        elif position == 0:
-            v_bonds = [position + 1]
-        elif position == len(self) - 1:
-            v_bonds = [position]
-        else:
-            v_bonds = [position, position + 1]
-
-        assert all(vb in self.tensors[position].bonds for vb in v_bonds)
-        return v_bonds
-
-    def get_virtual_dimensions(self, position: int) -> list[int]:
+    def get_virtual_dimensions(self, position: int) -> tuple[int, int]:
         """Returns the virtual bonds dimension of the tensor ``tensors[position]``.
 
         Args:
             position: A position in the MPS.
 
         Returns:
-            A list with the dimensions of the virtual bonds of the
-            tensor in order from left to right.
-            If ``position`` is the first or last in the MPS, then the list
-            will only contain the corresponding virtual bond.
-
-        Raises:
-            RuntimeError: If ``position`` is out of bounds.
-        """
-        return [
-            self.tensors[position].get_bond_dimension(bond)
-            for bond in self.get_virtual_bonds(position)
-        ]
-
-    def get_physical_bond(self, position: int) -> Bond:
-        """Returns the physical bond unique identifier of tensor ``tensors[position]``.
-
-        Args
-            position: A position in the MPS.
-
-        Returns:
-            The identifier of the physical bond.
+            A tuple where the first element is the dimensions of the left virtual bond
+            and the second elements is that of the right virtual bond.
 
         Raises:
             RuntimeError: If ``position`` is out of bounds.
@@ -681,8 +449,7 @@ class MPS:
         if position < 0 or position >= len(self):
             raise RuntimeError(f"Position {position} is out of bounds.")
 
-        # By construction, the largest identifier is the physical one
-        return max(self.tensors[position].bonds)
+        return self.tensors[position].shape[:2]
 
     def get_physical_dimension(self, position: int) -> int:
         """Returns the physical bond dimension of the tensor ``tensors[position]``.
@@ -696,16 +463,17 @@ class MPS:
         Raises:
             RuntimeError: If ``position`` is out of bounds.
         """
-        return self.tensors[position].get_bond_dimension(
-            self.get_physical_bond(position)
-        )
+        if position < 0 or position >= len(self):
+            raise RuntimeError(f"Position {position} is out of bounds.")
+
+        return self.tensors[position].shape[2]
 
     def get_device_id(self) -> int:
         """
         Returns:
             The identifier of the device (GPU) where the tensors are stored.
         """
-        return int(self.tensors[0].data.device)
+        return int(self.tensors[0].device)
 
     def update_libhandle(self, libhandle: CuTensorNetHandle) -> None:
         """Update the ``CuTensorNetHandle`` used by this ``MPS`` object. Multiple
@@ -739,6 +507,7 @@ class MPS:
         new_mps.truncation_fidelity = self.truncation_fidelity
         new_mps.fidelity = self.fidelity
         new_mps.tensors = [t.copy() for t in self.tensors]
+        new_mps.canonical_form = self.canonical_form.copy()
         new_mps.qubit_position = self.qubit_position.copy()
         new_mps._complex_t = self._complex_t
         new_mps._real_t = self._real_t

--- a/pytket/extensions/cutensornet/mps/mps_gate.py
+++ b/pytket/extensions/cutensornet/mps/mps_gate.py
@@ -162,13 +162,6 @@ class MPSxGate(MPS):
         R = self.tensors[r_pos]
         r_shape = list(R.data.shape)
 
-        if self.chi < new_dim:
-            new_dim = self.chi
-        if new_dim != r_shape[0]:
-            # We need to change the shape of the tensors
-            l_shape[-2] = new_dim
-            r_shape[0] = new_dim
-
         if self.truncation_fidelity < 1:
             # Carry out SVD decomposition first with NO truncation
             # to figure out where to apply the dimension cutoff.
@@ -254,12 +247,11 @@ class MPSxGate(MPS):
                 max_extent=self.chi,
                 partition="U",  # Contract S directly into U (named L in our case)
                 normalization="L2",  # Sum of squares equal 1
-                return_info=True,
             )
 
             subscripts = _bonds_to_subscripts([T_bonds], [L.bonds, R.bonds])
             L.data, S_d, R.data, svd_info = tensor.decompose(
-                subscripts, T_d, method=svd_method, options=options
+                subscripts, T_d, method=svd_method, options=options, return_info=True
             )
             assert S_d is None  # Due to "partition" option in SVDMethod
 

--- a/pytket/extensions/cutensornet/mps/mps_gate.py
+++ b/pytket/extensions/cutensornet/mps/mps_gate.py
@@ -66,7 +66,7 @@ class MPSxGate(MPS):
 
         # Contract
         new_tensor = cq.contract(
-            gate_bonds+","+T_bonds+"->"+result_bonds,
+            gate_bonds + "," + T_bonds + "->" + result_bonds,
             gate_tensor,
             self.tensors[position],
         )
@@ -131,7 +131,7 @@ class MPSxGate(MPS):
         if l_pos == positions[0]:
             gate_bonds = "LRlr"
         else:  # Implicit swap
-            gate_bonds = "RLrl" [right_new_bond, left_new_bond, right_p_bond, left_p_bond]
+            gate_bonds = "RLrl"
 
         left_bonds = "abl"
         right_bonds = "bcr"
@@ -139,7 +139,7 @@ class MPSxGate(MPS):
 
         # Contract
         T = cq.contract(
-            gate_bonds+","+left_bonds+","+right_bonds+"->"+result_bonds,
+            gate_bonds + "," + left_bonds + "," + right_bonds + "->" + result_bonds,
             gate_tensor,
             self.tensors[l_pos],
             self.tensors[r_pos],
@@ -183,7 +183,7 @@ class MPSxGate(MPS):
 
             # Take singular values until we surpass the target fidelity
             while self.truncation_fidelity > numer / denom:
-                numer += float(S_d[new_dim] ** 2)
+                numer += float(S[new_dim] ** 2)
                 new_dim += 1
             this_fidelity = numer / denom
 
@@ -263,7 +263,6 @@ class MPSxGate(MPS):
                 "acLR->asL,scR", T, method=tensor.QRMethod(), options=options
             )
 
-        # The L and R tensors have already been updated and these correspond
-        # to the entries of l_pos and r_pos in self.tensors
-        assert self.tensors[l_pos] is L and self.tensors[r_pos] is R
+        self.tensors[l_pos] = L
+        self.tensors[r_pos] = R
         return self

--- a/pytket/extensions/cutensornet/mps/mps_gate.py
+++ b/pytket/extensions/cutensornet/mps/mps_gate.py
@@ -22,13 +22,12 @@ except ImportError:
     warnings.warn("local settings failed to import cupy", ImportWarning)
 try:
     import cuquantum as cq  # type: ignore
-    import cuquantum.cutensornet as cutn  # type: ignore
     from cuquantum.cutensornet import tensor  # type: ignore
 except ImportError:
     warnings.warn("local settings failed to import cutensornet", ImportWarning)
 
 from pytket.circuit import Op  # type: ignore
-from .mps import Tensor, MPS, _bonds_to_subscripts
+from .mps import MPS, _bonds_to_subscripts
 
 
 class MPSxGate(MPS):

--- a/pytket/extensions/cutensornet/mps/mps_mpo.py
+++ b/pytket/extensions/cutensornet/mps/mps_mpo.py
@@ -24,7 +24,6 @@ except ImportError:
     warnings.warn("local settings failed to import cupy", ImportWarning)
 try:
     import cuquantum as cq  # type: ignore
-    import cuquantum.cutensornet as cutn  # type: ignore
     from cuquantum.cutensornet import tensor  # type: ignore
 except ImportError:
     warnings.warn("local settings failed to import cutensornet", ImportWarning)


### PR DESCRIPTION
Refactor of MPS algorithms so that every call to `tensor_svd` and `tensor_qr` are replaced with the higher level function `decompose` from cuTensorNet. This means that the following bits of code are no longer needed (and hence removed):

- No longer need to set a memory handler in the `CuTensorNetHandle`.
- No longer need to create/destroy tensor descriptors nor svd_config or svd_info objects.
- SVD configuration is much simpler and elegant.
- Bond IDs are now managed locally, i.e. we do not keep the bond IDs of the network around. This has some advantages:
  - Many lines of code are removed, since we need to keep track of one less thing.
  - Code readability of `MPSxGate` is greatly improved, since now `contract` uses the "subscript" notation, which is more human-readable.
  - The `MPSxMPO` algorithm does keep track of global bond IDs for the MPOs, since I found that's useful here. I don't think the code readability has improved that much here, but it's not worse than before.
- The `Tensor` class has been removed since we no longer need to keep track of bond IDs, nor generate tensor descriptors (thanks to the higher-level API from cuTensorNet).

Additionally, I have taken the liberty of sneaking in a few related changes:

- Whenever an SVD is not followed by a truncation, this is replaced with QR decomposition (much cheaper).
- Added an absolute cutoff to SVD operations, so that singular  values that are essentially zero (up to float precision) are automatically removed.
- Moved the `.use()` method of `cuda.Device` from `MPS` to `CuTensorNetHandle`, where it more naturally belongs.

Additionally, I have had a look at `contract_decompose` and `split_gate` from cuTensorNet. 
- My conclusion is that `split_gate` is never going to be useful for MPS, since the initial QR decompositions that are done would not decrease the rank of the tensors being SVD'd. Similarly for TreeTN, so this will only become useful when working with more general TN states. 
- On the other hand, `contract_decompose` is potentially useful since it doesn't just do `contract` then `decompose`, but keeps track of the max possible dimension of the shared bond and impose it in the decomposition. However, in the places I apply QR and SVD, I had already taken this into account, so I don't expect any performance improvement. It'd be non-trivial (but not too difficult either) to refactor the code to use `contract_decompose` and, since it's still in the `experimental` module, I'm not using it for now, but I'll keep an eye on it.