### PR TITLE
Feature/mps sampling

### DIFF
--- a/docs/modules/mps.rst
+++ b/docs/modules/mps.rst
@@ -12,8 +12,6 @@ Simulation
 
 .. autofunction:: pytket.extensions.cutensornet.mps.simulate
 
-.. autofunction:: pytket.extensions.cutensornet.mps.get_amplitude
-
 
 Classes
 ~~~~~~~
@@ -24,6 +22,13 @@ Classes
     .. automethod:: apply_gate
     .. automethod:: vdot
     .. automethod:: canonicalise
+    .. automethod:: sample
+    .. automethod:: measure
+    .. automethod:: postselect
+    .. automethod:: expected_value
+    .. automethod:: get_statevector
+    .. automethod:: get_amplitude
+    .. automethod:: get_qubits
     .. automethod:: get_virtual_dimensions
     .. automethod:: get_physical_dimension
     .. automethod:: get_device_id

--- a/docs/modules/mps.rst
+++ b/docs/modules/mps.rst
@@ -25,7 +25,7 @@ Classes
     .. automethod:: sample
     .. automethod:: measure
     .. automethod:: postselect
-    .. automethod:: expected_value
+    .. automethod:: expectation_value
     .. automethod:: get_statevector
     .. automethod:: get_amplitude
     .. automethod:: get_qubits

--- a/examples/mps_tutorial.ipynb
+++ b/examples/mps_tutorial.ipynb
@@ -9,6 +9,7 @@
    "source": [
     "import numpy as np\n",
     "from time import time\n",
+    "import matplotlib.pyplot as plt\n",
     "from pytket import Circuit\n",
     "from pytket.circuit.display import render_circuit_jupyter\n",
     "\n",
@@ -16,7 +17,6 @@
     "    CuTensorNetHandle,\n",
     "    ContractionAlg,\n",
     "    simulate, \n",
-    "    get_amplitude, \n",
     "    prepare_circuit\n",
     ")"
    ]
@@ -97,7 +97,7 @@
        "\n",
        "\n",
        "\n",
-       "    &lt;div id=&#34;circuit-display-vue-container-3af59909-1a56-4473-9a34-647cee86f213&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-f6589290-2356-4b8d-a825-fc39b4059b95&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
        "        &lt;div style=&#34;display: none&#34;&gt;\n",
        "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.2&#34;], &#34;type&#34;: &#34;Ry&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;, &#34;0.5&#34;, &#34;0.7&#34;], &#34;type&#34;: &#34;TK2&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [4]], [&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.1&#34;], &#34;type&#34;: &#34;ZZPhase&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]], [[&#34;q&#34;, [3]], [&#34;q&#34;, [3]]], [[&#34;q&#34;, [4]], [&#34;q&#34;, [4]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [3]], [&#34;q&#34;, [4]]]}&lt;/div&gt;\n",
        "        &lt;/div&gt;\n",
@@ -107,7 +107,7 @@
        "        &gt;&lt;/circuit-display-container&gt;\n",
        "    &lt;/div&gt;\n",
        "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
-       "      const circuitRendererUid = &#34;3af59909-1a56-4473-9a34-647cee86f213&#34;;\n",
+       "      const circuitRendererUid = &#34;f6589290-2356-4b8d-a825-fc39b4059b95&#34;;\n",
        "      const displayOptions = JSON.parse(&#39;{}&#39;);\n",
        "\n",
        "      // Script to initialise the circuit renderer app\n",
@@ -216,7 +216,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(0.0396888408977374+0.054627003056102616j)\n"
+      "(0.039688840897737394+0.05462700305610265j)\n"
      ]
     }
    ],
@@ -224,7 +224,7 @@
     "state = int('10100', 2)\n",
     "with CuTensorNetHandle() as libhandle:\n",
     "    my_mps.update_libhandle(libhandle)\n",
-    "    amplitude = get_amplitude(my_mps, state)\n",
+    "    amplitude = my_mps.get_amplitude(state)\n",
     "print(amplitude)"
    ]
   },
@@ -259,10 +259,81 @@
     "with CuTensorNetHandle() as libhandle:\n",
     "    my_mps.update_libhandle(libhandle)\n",
     "    for i in range(2**n_qubits):\n",
-    "        correct_amplitude[i] = np.isclose(state_vector[i], get_amplitude(my_mps, i))\n",
+    "        correct_amplitude[i] = np.isclose(state_vector[i], my_mps.get_amplitude(i))\n",
     "\n",
     "print(\"Are all amplitudes correct?\")\n",
     "print(all(correct_amplitude))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4b00cb2-9871-4768-9b25-00cf25101828",
+   "metadata": {},
+   "source": [
+    "### Sampling from an MPS\n",
+    "\n",
+    "We can also sample from the output state of a circuit by calling `my_mps.sample`, where `my_mps` is the outcome of simulating the circuit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "434e6b70-0ed0-4677-b97b-3c396db87b21",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAGwCAYAAACzXI8XAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAABDUUlEQVR4nO3deVyVdd7/8fcRZYeDoGyBe2rmUloqU5klKdo4mk6Laal1252j5dJM6p2l5nTT8iuXbjOzeyRvU5tKWyfNTKgp3DBzaxx1UNBYyuUgKAeD6/cHw8kjoIjAdS54PR+P61Hn2s7nWvS8va7v9b1shmEYAgAAsKBGZhcAAABQXQQZAABgWQQZAABgWQQZAABgWQQZAABgWQQZAABgWQQZAABgWY3NLqC2lZSU6Mcff1RQUJBsNpvZ5QAAgCowDEOnT59WdHS0GjWq/LpLvQ8yP/74o2JjY80uAwAAVENmZqZiYmIqnV7vg0xQUJCk0h0RHBxscjUAAKAq8vLyFBsb6/odr0y9DzJlt5OCg4MJMgAAWMylmoXQ2BcAAFgWQQYAAFgWQQYAAFhWvW8jAwDwXCUlJSoqKjK7DJigSZMm8vLyuuL1EGQAAKYoKipSenq6SkpKzC4FJgkJCVFkZOQV9fNGkAEA1DnDMJSVlSUvLy/FxsZetMMz1D+GYejMmTPKzc2VJEVFRVV7XQQZAECd++WXX3TmzBlFR0fL39/f7HJgAj8/P0lSbm6uwsPDq32biQgMAKhzxcXFkiRvb2+TK4GZykLsuXPnqr0OggwAwDS8A69hq4njz62laiguMbQ1/YRyTxcqPMhXPVuHyqsRfxitjGMKANZEkLlM6/Zkac7H+5TlKHSNi7L7atbgTkroXP3GSjAPxxQArItbS5dh3Z4sjV+xw+0HT5KyHYUav2KH1u3JMqkyVBfHFEBNSk5Ols1m06lTp8wupcEgyFRRcYmhOR/vk1HBtLJxcz7ep+KSiuaAJ+KYAtZXXGIo9dBxfbjzmFIPHa/VP682m+2iw+zZs2vtu1E5bi1V0db0E+X+1X4+Q1KWo1Bb008orm1Y3RWGauOYAtZW17eFs7J+vUL7zjvv6JlnntH+/ftd4wIDA7V9+/Ya/96qKCoqarBPgHFFpopyT1f+g1ed+WA+jilgXWbcFo6MjHQNdrtdNpvNbVxgYKBr3rS0NN1www3y9/fXb37zG7fAI0kffvihunfvLl9fX7Vp00Zz5szRL7/84pqekZGhIUOGKDAwUMHBwbrnnnuUk5Pjmj579mxdd911evPNN9W6dWv5+vpq+fLlCgsLk9PpdPuuoUOH6oEHHqjx/eEpCDJVFB7kW6PzwXwcU8CarHBb+KmnntLLL7+s7du3q3HjxnrooYdc077++ms9+OCDmjRpkvbt26clS5YoKSlJzz33nKTS908NGTJEJ06cUEpKijZs2KB//etfuvfee92+4+DBg3r//fe1Zs0a7dy5U3fffbeKi4v10UcfuebJzc3Vp59+6vb99Q1Bpop6tg5VlN1XlT2Qa1PpJc2erUPrsixcgZ6tQ9UuuFhROl7h9CgdV7vgYo4p4GEu57awWZ577jndeuut6tSpk6ZPn65vv/1WhYWlNc+ZM0fTp0/X6NGj1aZNG91xxx2aO3eulixZIknauHGjdu/erZUrV6pHjx7q1auXli9frpSUFG3bts31HUVFRVq+fLmuv/56de3aVX5+frr//vu1bNky1zwrVqxQixYt1Ldv3zrd/rpEkKkir0Y2zRrcSZLKhZmyz7MGd6LvEQvxKsrTe4H/T6u95yr6gjATreNa7T1X7wX+P3kV5ZlUIYCKWOG2cNeuXV3/X/YeobL3Cn3//fd69tlnFRgY6BrGjRunrKwsnTlzRj/88INiY2MVGxvrWkenTp0UEhKiH374wTWuZcuWat68udv3jhs3Tp9//rmOHTsmSUpKStKYMWPqdceDHhNknn/+edlsNk2ePNk1rrCwUBMmTFBYWJgCAwM1fPhwt3uEdS2hc5QWj+quSLv7rYZIu68Wj+pOnyNW48xXiOFQy0a5+qvvn11XZqJ0XH/1/bNaNspViOGQnPkmFwrgfFa4LdykSRPX/5eFiLK3fOfn52vOnDnauXOna9i9e7cOHDggX9+q1xwQEFBu3PXXX69u3bpp+fLlSktL0969ezVmzJgr2xgP5xFPLW3btk1LlixxS7CSNGXKFH366ad69913ZbfbNXHiRA0bNkzffPONSZWWhpk7OkXSC2x9YL9KGvOplHSnYk4e1qZmL2nr9Ynq+d1L8s3PkZq2Kp1uv8rsSgGcp+xWf7ajsMJ2MjaV/gPTU28Ld+/eXfv371e7du0qnH7NNdcoMzNTmZmZrqsy+/bt06lTp9SpU6dLrv8//uM/NH/+fB07dkzx8fFuV3bqI9OvyOTn52vkyJFaunSpmjZt6hrvcDj0v//7v3rllVd0++23q0ePHlq2bJm+/fZbbd68udL1OZ1O5eXluQ01zauRTXFtwzTkuqsU1zaMEGNl9pjSsNK0lXzzM9Tn65Hyzc84L8TEmF0hgAtY/Vb/M888o+XLl2vOnDnau3evfvjhB61evVozZ86UJMXHx6tLly4aOXKkduzYoa1bt+rBBx/UrbfeqhtuuOGS67///vt19OhRLV26tF438i1jepCZMGGC7rzzTsXHx7uNT0tL07lz59zGd+zYUS1atFBqamql60tMTJTdbncN9T2JogbYY6S73nAfd9cbhBjAg1n5Vv+AAQP0ySef6PPPP9eNN96o3r17a968eWrZsqWk0ltRH374oZo2bao+ffooPj5ebdq00TvvvFOl9dvtdg0fPlyBgYEaOnRoLW6JZ7AZhmHa82mrV6/Wc889p23btsnX11d9+/bVddddp/nz52vlypUaO3Zsuefhe/bsqdtuu00vvPBChet0Op1uy+Tl5Sk2NlYOh0PBwcG1uj2wKMdRKelO6eThX8dxRQaoVYWFhUpPT3f1gVJdvPC1Yv369dO1116rhQsXml3KRV3sPMjLy5Pdbr/k77dpbWQyMzM1adIkbdiw4YpO4gv5+PjIx8enxtaHeu78ENO0VemVmLWPlH5OupMwA3i4slv9KHXy5EklJycrOTlZr732mtnl1AnTbi2lpaUpNzdX3bt3V+PGjdW4cWOlpKRo4cKFaty4sSIiIlRUVFTuxVs5OTmKjIw0p2jUL45j7iFmzKdSi16uNjOuMOM4Zm6dAFBF119/vcaMGaMXXnhBHTp0MLucOmHaFZl+/fpp9+7dbuPGjh2rjh07atq0aYqNjVWTJk20ceNGDR8+XJK0f/9+ZWRkKC4uzoySpcJ/P4pb0VMsjmOST6Dka6/7ulA9PoFSwL/7YDj/yktZA+CkO0un+wRWvg4A8CCHDx82u4Q6Z1qQCQoKUufOnd3GBQQEKCwszDX+4Ycf1tSpUxUaGqrg4GA99thjiouLU+/eveu+4EKHtGK4VPBT+dsNZbcnAppLo94nzFiFr730eFUUTu0x0pi/EU4BwMN5RD8ylZk3b54aNWqk4cOHy+l0asCAAebd83Pml4aYC9tOXNhQ1JnPD5+V+NorP170HwMAHs/Up5bqQlVbPVfJxRqG8pQLAFRZTT21BGuriaeWTO9HxlLO6zxNJw9Lf+lPiAEAwEQEmctF52kAAHgMgszlchwtvZ10vrWPlI4HAMBEY8aMaRC9+Z6PIHM5Lmwj89DnF/Q3QpgBgPpuzJgxstls5YaEhASzS9OCBQuUlJRkdhmSSl+18MEHH9T693j0U0sepaLO087vb8T1NNPfeNoFAGqbyf16JSQkaNmyZW7jzOxVvri4WDabTXZ7w3tqlisyVVXWedqFDXvPbwBM52kAUPvK+vVKGlT+SrjjaOn4FcNL56slPj4+ioyMdBuaNm2q5ORkeXt76+uvv3bN++KLLyo8PFw5OTmSpL59+2rixImaOHGi7Ha7mjVrpqefflrnP0TsdDr1xz/+UVdddZUCAgLUq1cvJScnu6YnJSUpJCREH330kTp16iQfHx9lZGSUu7XUt29fPfbYY5o8ebKaNm2qiIgILV26VAUFBRo7dqyCgoLUrl07ffbZZ27bt2fPHg0cOFCBgYGKiIjQAw88oJ9//tltvY8//riefPJJhYaGKjIyUrNnz3ZNb9WqlSTprrvuks1mc32uDQSZqirrPG3M38o37C3rPI3O8ACg9l3Yr1dZmDn/9n/BT6Xz1bG+fftq8uTJeuCBB+RwOPTdd9/p6aef1ptvvqmIiAjXfG+99ZYaN26srVu3asGCBXrllVf05ptvuqZPnDhRqampWr16tXbt2qW7775bCQkJOnDggGueM2fO6IUXXtCbb76pvXv3Kjw8vMKa3nrrLTVr1kxbt27VY489pvHjx+vuu+/Wb37zG+3YsUP9+/fXAw88oDNnzkiSTp06pdtvv13XX3+9tm/frnXr1iknJ0f33HNPufUGBARoy5YtevHFF/Xss89qw4YNkqRt27ZJkpYtW6asrCzX51ph1HMOh8OQZDgcDrNLAQD829mzZ419+/YZZ8+erd4KTmUaxvyuhjEruPS/Rza7fz6VWbMFn2f06NGGl5eXERAQ4DY899xzhmEYhtPpNK677jrjnnvuMTp16mSMGzfObflbb73VuOaaa4ySkhLXuGnTphnXXHONYRiGceTIEcPLy8s4duyY23L9+vUzZsyYYRiGYSxbtsyQZOzcubNcbUOGDHH7rptvvtn1+ZdffjECAgKMBx54wDUuKyvLkGSkpqYahmEYc+fONfr37++23szMTEOSsX///grXaxiGceONNxrTpk1zfZZkrF27tpK9WOpi50FVf79pIwMAsJ4L2yj+pX/p+Drq1+u2227T4sWL3caFhoZKkry9vfX222+ra9euatmypebNm1du+d69e8tms7k+x8XF6eWXX1ZxcbF2796t4uJitW/f3m0Zp9OpsLBf3/Tt7e2trl27XrLW8+fx8vJSWFiYunTp4hpXdqUoNzdXkvT9999r06ZNCgws31Ti0KFDrrou/O6oqCjXOuoSQQYAYE1l/XqVhRipzvr1CggIULt27Sqd/u2330qSTpw4oRMnTiggIKDK687Pz5eXl5fS0tLk5eXlNu38cOHn5+cWhirTpEkTt882m81tXNk6SkpKXN8/ePBgvfDCC+XWFRUVddH1lq2jLhFkAADWVFm/Xib3tH7o0CFNmTJFS5cu1TvvvKPRo0friy++UKNGvzZL3bJli9symzdv1tVXXy0vLy9df/31Ki4uVm5urm655Za6Ll/du3fX+++/r1atWqlx4+rHhCZNmqi4uLgGK6sYjX0BANZjcr9eTqdT2dnZbsPPP/+s4uJijRo1SgMGDNDYsWO1bNky7dq1Sy+//LLb8hkZGZo6dar279+vVatW6dVXX9WkSZMkSe3bt9fIkSP14IMPas2aNUpPT9fWrVuVmJioTz/9tFa3S5ImTJigEydOaMSIEdq2bZsOHTqk9evXa+zYsZcVTFq1aqWNGzcqOztbJ0+erLV6CTIAAGupqF+vFr3c34WXdGfpfLVk3bp1ioqKchtuvvlmPffcczpy5IiWLFkiqfRWzBtvvKGZM2fq+++/dy3/4IMP6uzZs+rZs6cmTJigSZMm6ZFHfr26tGzZMj344IN64okn1KFDBw0dOlTbtm1TixYtam2bykRHR+ubb75RcXGx+vfvry5dumjy5MkKCQlxu6p0KS+//LI2bNig2NhYXX/99bVWL2+/BgDUuSt6+3VZPzIFP5W/jVR2pSagucd2idG3b19dd911mj9/vtmlmK4m3n5NGxkAgLWU9etVUc++Zf161XLPvvAcBBkAgPX42isPKrwmpkEhyAAAUIfOf9UArhyNfQEAgGURZAAApqnnz5vgEmri+BNkAAB1rqzH2qKiIpMrgZnKXlR5YS/Bl4M2MgCAOte4cWP5+/vrp59+UpMmTS6rfxJYn2EYOnPmjHJzcxUSElLuVQyXgyADAKhzNptNUVFRSk9P15EjR8wuByYJCQlRZGTkFa2DIAMAMIW3t7euvvpqbi81UE2aNLmiKzFlCDIAANM0atTo8nv2Bc7DTUkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZpgaZxYsXq2vXrgoODlZwcLDi4uL02Wefuab37dtXNpvNbXj00UdNrBgAAHgSU/uRiYmJ0fPPP6+rr75ahmHorbfe0pAhQ/Tdd9/p2muvlSSNGzdOzz77rGsZf39/s8oFAAAextQgM3jwYLfPzz33nBYvXqzNmze7goy/v/9ldV/sdDrldDpdn/Py8mqmWAAA4HE8po1McXGxVq9erYKCAsXFxbnGv/3222rWrJk6d+6sGTNmuN6UWZnExETZ7XbXEBsbW9ulAwAAk9gMwzDMLGD37t2Ki4tTYWGhAgMDtXLlSg0aNEiS9MYbb6hly5aKjo7Wrl27NG3aNPXs2VNr1qypdH0VXZGJjY2Vw+FQcHBwrW8PAAC4cnl5ebLb7Zf8/TY9yBQVFSkjI0MOh0Pvvfee3nzzTaWkpKhTp07l5v3yyy/Vr18/HTx4UG3btq3S+qu6IwAAgOeo6u+36beWvL291a5dO/Xo0UOJiYnq1q2bFixYUOG8vXr1kiQdPHiwLksEAAAeyvQgc6GSkhK3W0Pn27lzpyQpKiqqDisCAACeytSnlmbMmKGBAweqRYsWOn36tFauXKnk5GStX79ehw4dcrWXCQsL065duzRlyhT16dNHXbt2NbNsAADgIUwNMrm5uXrwwQeVlZUlu92url27av369brjjjuUmZmpL774QvPnz1dBQYFiY2M1fPhwzZw508ySAQCABzG9sW9to7EvAADWY5nGvgAAANVFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZlapBZvHixunbtquDgYAUHBysuLk6fffaZa3phYaEmTJigsLAwBQYGavjw4crJyTGxYgAA4ElMDTIxMTF6/vnnlZaWpu3bt+v222/XkCFDtHfvXknSlClT9PHHH+vdd99VSkqKfvzxRw0bNszMkgEAgAexGYZhmF3E+UJDQ/XSSy/p97//vZo3b66VK1fq97//vSTpH//4h6655hqlpqaqd+/eVVpfXl6e7Ha7HA6HgoODa7N0AABQQ6r6++0xbWSKi4u1evVqFRQUKC4uTmlpaTp37pzi4+Nd83Ts2FEtWrRQampqpetxOp3Ky8tzGwAAQP1kepDZvXu3AgMD5ePjo0cffVRr165Vp06dlJ2dLW9vb4WEhLjNHxERoezs7ErXl5iYKLvd7hpiY2NreQsAAIBZTA8yHTp00M6dO7VlyxaNHz9eo0eP1r59+6q9vhkzZsjhcLiGzMzMGqwWAAB4ksZmF+Dt7a127dpJknr06KFt27ZpwYIFuvfee1VUVKRTp065XZXJyclRZGRkpevz8fGRj49PbZcNAAA8gOlXZC5UUlIip9OpHj16qEmTJtq4caNr2v79+5WRkaG4uDgTKwQAAJ7C1CsyM2bM0MCBA9WiRQudPn1aK1euVHJystavXy+73a6HH35YU6dOVWhoqIKDg/XYY48pLi6uyk8sAQCA+s3UIJObm6sHH3xQWVlZstvt6tq1q9avX6877rhDkjRv3jw1atRIw4cPl9Pp1IABA/Taa6+ZWTIAAPAgHtePTE2jHxkAAKzHcv3IAAAAXC6CDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCxTg0xiYqJuvPFGBQUFKTw8XEOHDtX+/fvd5unbt69sNpvb8Oijj5pUMQAA8CSmBpmUlBRNmDBBmzdv1oYNG3Tu3Dn1799fBQUFbvONGzdOWVlZruHFF180qWIAAOBJGpv55evWrXP7nJSUpPDwcKWlpalPnz6u8f7+/oqMjKzr8gAAgIfzqDYyDodDkhQaGuo2/u2331azZs3UuXNnzZgxQ2fOnKl0HU6nU3l5eW4DAACon0y9InO+kpISTZ48WTfddJM6d+7sGn///ferZcuWio6O1q5duzRt2jTt379fa9asqXA9iYmJmjNnTl2VDQAATGQzDMMwuwhJGj9+vD777DP9/e9/V0xMTKXzffnll+rXr58OHjyotm3blpvudDrldDpdn/Py8hQbGyuHw6Hg4OBaqR0AANSsvLw82e32S/5+e8QVmYkTJ+qTTz7RV199ddEQI0m9evWSpEqDjI+Pj3x8fGqlTgAA4FlMDTKGYeixxx7T2rVrlZycrNatW19ymZ07d0qSoqKiark6AADg6UwNMhMmTNDKlSv14YcfKigoSNnZ2ZIku90uPz8/HTp0SCtXrtSgQYMUFhamXbt2acqUKerTp4+6du1qZukAAMADmNpGxmazVTh+2bJlGjNmjDIzMzVq1Cjt2bNHBQUFio2N1V133aWZM2dWub1LVe+xAQAAz2GJNjKXylCxsbFKSUmpo2oAAIDVeFQ/MgAAAJeDIAMAACyLIAMAACyrWkEmMzNTR48edX3eunWrJk+erDfeeKPGCgMAALiUagWZ+++/X5s2bZIkZWdn64477tDWrVv11FNP6dlnn63RAgEAACpTrSCzZ88e9ezZU5L017/+VZ07d9a3336rt99+W0lJSTVZHwAAQKWqFWTOnTvneg3AF198od/97neSpI4dOyorK6vmqgMAALiIagWZa6+9Vq+//rq+/vprbdiwQQkJCZKkH3/8UWFhYTVaIAAAQGWqFWReeOEFLVmyRH379tWIESPUrVs3SdJHH33kuuUEAABQ26r9ioLi4mLl5eWpadOmrnGHDx+Wv7+/wsPDa6zAK8UrCgAAsJ6q/n5Xux8ZwzCUlpamJUuW6PTp05Ikb29v+fv7V3eVAAAAl6Va71o6cuSIEhISlJGRIafTqTvuuENBQUF64YUX5HQ69frrr9d0nQAAAOVU64rMpEmTdMMNN+jkyZPy8/Nzjb/rrru0cePGGisOAADgYqp1Rebrr7/Wt99+K29vb7fxrVq10rFjx2qkMAAAgEup1hWZkpISFRcXlxt/9OhRBQUFXXFRAAAAVVGtINO/f3/Nnz/f9dlmsyk/P1+zZs3SoEGDaqo2AACAi6rW49dHjx7VgAEDZBiGDhw4oBtuuEEHDhxQs2bN9NVXX/H4NQAAuCJV/f2udj8yv/zyi1avXq1du3YpPz9f3bt318iRI90a/3oCggwAANZT1d/vajX2laTGjRtr1KhR1V0cAADgilU5yHz00UdVXmnZSyQBAABqU5WDzNChQ6s0n81mq/CJJgAAgJpW5SBTUlJSm3UAAABctmq/awkAAMBs1Q4yGzdu1G9/+1u1bdtWbdu21W9/+1t98cUXNVkbAADARVUryLz22mtKSEhQUFCQJk2apEmTJik4OFiDBg3SokWLarpGAACAClWrH5mYmBhNnz5dEydOdBu/aNEi/fd//7dHvW+JfmQAALCeqv5+V+uKzKlTp5SQkFBufP/+/eVwOKqzSgAAgMtWrSDzu9/9TmvXri03/sMPP9Rvf/vbKy4KAACgKqrVs2+nTp303HPPKTk5WXFxcZKkzZs365tvvtETTzyhhQsXuuZ9/PHHa6ZSAACAC1SrjUzr1q2rtnKbTf/6178uu6iaRBsZAACsp1bftZSenl7tws6XmJioNWvW6B//+If8/Pz0m9/8Ri+88II6dOjgmqewsFBPPPGEVq9eLafTqQEDBui1115TREREjdQAAACsy9QO8VJSUjRhwgRt3rxZGzZs0Llz59S/f38VFBS45pkyZYo+/vhjvfvuu0pJSdGPP/6oYcOGmVg1AADwFNW6tWQYht577z1t2rRJubm55V5fsGbNmmoV89NPPyk8PFwpKSnq06ePHA6HmjdvrpUrV+r3v/+9JOkf//iHrrnmGqWmpqp3796XXCe3lgAAsJ5affx68uTJeuCBB5Senq7AwEDZ7Xa3obrKHt0ODQ2VJKWlpencuXOKj493zdOxY0e1aNFCqampFa7D6XQqLy/PbQAAAPVTtdrI/N///Z/WrFmjQYMG1VghJSUlmjx5sm666SZ17txZkpSdnS1vb2+FhIS4zRsREaHs7OwK15OYmKg5c+bUWF0AAMBzVeuKjN1uV5s2bWq0kAkTJmjPnj1avXr1Fa1nxowZcjgcriEzM7OGKgQAAJ6mWkFm9uzZmjNnjs6ePVsjRUycOFGffPKJNm3apJiYGNf4yMhIFRUV6dSpU27z5+TkKDIyssJ1+fj4KDg42G0AAAD1U7VuLd1zzz1atWqVwsPD1apVKzVp0sRt+o4dO6q0HsMw9Nhjj2nt2rVKTk4u1z9Njx491KRJE23cuFHDhw+XJO3fv18ZGRmujvgAAEDDVa0gM3r0aKWlpWnUqFGKiIiQzWar1pdPmDBBK1eu1IcffqigoCBXuxe73S4/Pz/Z7XY9/PDDmjp1qkJDQxUcHKzHHntMcXFxVXpiCQAA1G/Vevw6ICBA69ev180333xlX15JAFq2bJnGjBkj6dcO8VatWuXWIV5lt5YuxOPXAABYT6327BsbG1sjoaAqGcrX11eLFi3SokWLrvj7AABA/VKtxr4vv/yynnzySR0+fLiGywEAAKi6al2RGTVqlM6cOaO2bdvK39+/XGPfEydO1EhxAAAAF1OtIDN//vwaLgMAAODyVfupJQAAALNVK8icr7CwUEVFRW7jeDoIAADUhWo19i0oKNDEiRMVHh6ugIAANW3a1G0AAACoC9UKMk8++aS+/PJLLV68WD4+PnrzzTc1Z84cRUdHa/ny5TVdIwAAQIWqdWvp448/1vLly9W3b1+NHTtWt9xyi9q1a6eWLVvq7bff1siRI2u6TgAAgHKqdUXmxIkTrrdfBwcHux63vvnmm/XVV1/VXHUAAAAXUa0g06ZNG6Wnp0uSOnbsqL/+9a+SSq/UhISE1FhxAAAAF1OtIDN27Fh9//33kqTp06dr0aJF8vX11ZQpU/SnP/2pRgsEAACoTLVeGnmhI0eOKC0tTe3atVPXrl1roq4aw0sjAQCwnqr+fl/WFZnU1FR98sknbuPKGv0++uij+p//+R85nc7qVQwAAHCZLivIPPvss9q7d6/r8+7du/Xwww8rPj5eM2bM0Mcff6zExMQaLxIAAKAilxVkdu7cqX79+rk+r169Wr169dLSpUs1ZcoULVy40NXwFwAAoLZdVpA5efKkIiIiXJ9TUlI0cOBA1+cbb7xRmZmZNVcdAADARVxWkImIiHA9dl1UVKQdO3aod+/erumnT59WkyZNarZCAACASlxWkBk0aJCmT5+ur7/+WjNmzJC/v79uueUW1/Rdu3apbdu2NV4kAABARS7rFQVz587VsGHDdOuttyowMFBvvfWWvL29XdP/8pe/qH///jVeJAAAQEWq1Y+Mw+FQYGCgvLy83MafOHFCgYGBbuHGbPQjAwCA9VT197taL4202+0Vjg8NDa3O6gAAAKqlWq8oAAAA8AQEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFmmBpmvvvpKgwcPVnR0tGw2mz744AO36WPGjJHNZnMbEhISzCkWAAB4HFODTEFBgbp166ZFixZVOk9CQoKysrJcw6pVq+qwQgAA4Mmq9a6lmjJw4EANHDjwovP4+PgoMjKyjioCAABW4vFtZJKTkxUeHq4OHTpo/PjxOn78+EXndzqdysvLcxsAAED95NFBJiEhQcuXL9fGjRv1wgsvKCUlRQMHDlRxcXGlyyQmJsput7uG2NjYOqwYAADUJZthGIbZRUiSzWbT2rVrNXTo0Ern+de//qW2bdvqiy++UL9+/Sqcx+l0yul0uj7n5eUpNjZWDodDwcHBNV02AACoBXl5ebLb7Zf8/fboKzIXatOmjZo1a6aDBw9WOo+Pj4+Cg4PdBgAAUD9ZKsgcPXpUx48fV1RUlNmlAAAAD2DqU0v5+fluV1fS09O1c+dOhYaGKjQ0VHPmzNHw4cMVGRmpQ4cO6cknn1S7du00YMAAE6sGAACewtQgs337dt12222uz1OnTpUkjR49WosXL9auXbv01ltv6dSpU4qOjlb//v01d+5c+fj4mFUyAADwIB7T2Le2VLWxEAAA8Bz1srEvAADA+QgyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAsggyAADAskwNMl999ZUGDx6s6Oho2Ww2ffDBB27TDcPQM888o6ioKPn5+Sk+Pl4HDhwwp1gAAOBxTA0yBQUF6tatmxYtWlTh9BdffFELFy7U66+/ri1btiggIEADBgxQYWFhHVcKAAA8UWMzv3zgwIEaOHBghdMMw9D8+fM1c+ZMDRkyRJK0fPlyRURE6IMPPtB9991Xl6UCAAAP5LFtZNLT05Wdna34+HjXOLvdrl69eik1NbXS5ZxOp/Ly8twGAABQP3lskMnOzpYkRUREuI2PiIhwTatIYmKi7Ha7a4iNja3VOgEAgHk8NshU14wZM+RwOFxDZmam2SUBAIBa4rFBJjIyUpKUk5PjNj4nJ8c1rSI+Pj4KDg52GwAAQP3ksUGmdevWioyM1MaNG13j8vLytGXLFsXFxZlYGQAA8BSmPrWUn5+vgwcPuj6np6dr586dCg0NVYsWLTR58mT9+c9/1tVXX63WrVvr6aefVnR0tIYOHWpe0QAAwGOYGmS2b9+u2267zfV56tSpkqTRo0crKSlJTz75pAoKCvTII4/o1KlTuvnmm7Vu3Tr5+vqaVTIAAPAgNsMwDLOLqE15eXmy2+1yOBy0lwEAwCKq+vvtsW1kAAAALoUgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgg4oVOiTHsYqnOY6VTgc8Dect0OAQZFBeoUNaMVxKGiQ5jrpPcxwtHb9iOD8K8Cyct0CDRJBBec58qeAn6eRhKenOX38UHEdLP588XDrdmW9mlYA7zlugQSLIoDz7VdKYT6WmrX79UcjY8uuPQdNWpdPtV5lbJ3A+zlugQbIZhmGYXURtysvLk91ul8PhUHBwsNnlWMv5/5It4/oxiDGrKuDiOG+BeqGqv99ckUHl7DHSXW+4j7vrDX4M4Nk4b4EGhSCDyjmOSmsfcR+39pHyDSkBT8J5CzQoBBlU7PzL801bSQ997t72gB8FeCLOW6DBIcigPMex8g0kW/Qq35Cysv464HkaQv8qnLdAg+TRQWb27Nmy2WxuQ8eOHc0uq/7zCZQCmpdvIGmP+fVHIaB56XzwfA2lfxXOW6BBamx2AZdy7bXX6osvvnB9btzY40u2Pl+7NOr90v42LnxU1R4jjflb6Y+Br92c+nB5LuxfpexH/sKne5z51j6mnLdAg+TxqaBx48aKjIw0u4yGx9de+V/49MNhLWX9q5SFlqQ7S5/iWftI/etfhfMWaHA8+taSJB04cEDR0dFq06aNRo4cqYyMjIvO73Q6lZeX5zYADd75t1dOHpb+0v+CEMOjyQCsyaODTK9evZSUlKR169Zp8eLFSk9P1y233KLTp09XukxiYqLsdrtriI2NrcOK65/iEkOph47rw53HlHrouIpL6nX/ifWbPUbFQ5e4jSoeuqRehhjO2/qHY4rKWKpn31OnTqlly5Z65ZVX9PDDD1c4j9PplNPpdH3Oy8tTbGwsPftWw7o9WZrz8T5lOQpd46Lsvpo1uJMSOkeZWBmqI3nrDrX7232KUY5r3FFF6OCg1erbs7uJldUsztv6h2PaMNXLnn1DQkLUvn17HTx4sNJ5fHx8FBwc7Dbg8q3bk6XxK3a4/cUhSdmOQo1fsUPr9mSZVBmqI3nrDrX+5F7FKEdHSsI1zDlbR0rCFaMctf7kXiVv3WF2iTWC87b+4ZjiUiwVZPLz83Xo0CFFRZHAa1NxiaE5H+9TRZfqysbN+Xgfl3YtovjUUbX7231q2ShXR0rCdV/R09phtNd9RU/rSEm4WjbKVbu/3afiU9buLI7ztv7hmKIqPDrI/PGPf1RKSooOHz6sb7/9VnfddZe8vLw0YsQIs0ur17amnyj3r5/zGZKyHIXamn6i7opCtaVlnVNuSZArxGQpTJKUpTBXmMktCVJa1jmTK70ynLf1D8cUVeHRj18fPXpUI0aM0PHjx9W8eXPdfPPN2rx5s5o3b252afVa7unK/+KoznwwV5bTWzOLpitAZ5X97xDjmqYw3Vv0tArkpz87vU2qsGZw3tY/HFNUhUcHmdWrV5tdQoMUHuRbo/PBXOFBvjotf52Wf4XTy8KN1Y8n5239wzFFVXj0rSWYo2frUEXZfWWrZLpNpU8M9GwdWpdloZoayvFsKNvZkHBMURUEGZTj1cimWYM7SVK5v0DKPs8a3ElejSr76wWepKEcz4aynQ0JxxRVQZBBhRI6R2nxqO6KtLtfso20+2rxqO703WAxDeV4NpTtbEg4prgUS3WIVx1V7VAHFSsuMbQ1/YRyTxcqPKj0Ei7/+rGuhnI8G8p2NiQc04anqr/fBBkAgOcqdFT8RnNJchzjjeb1WL3s2RcA0IAUOqQVw6WkQZLjgg4bHUdLx68YXjofGiyCDADAMznzpYKfSt/UnnTnr2HGcbT088nDpdOd+WZWCZMRZAAAnsl+lTTmU6lpq1/DTMaWX0NM01al0yu67YQGgyADAPBc9hj3MPOX/heEmBhz64PpCDIAAM9mj5HuesN93F1vEGIgiSADAPB0jqPS2kfcx619pHwDYDRIBBkAgOc6v2Fv01bSQ5+7t5khzDR4BBkAgGdyHCvfsLdFr/INgB3HzK0TpiLIAAA8k0+gFNC8fMPe8xsABzQvnQ8NVmOzCwAAoEK+dmnU+xX37GuPkcb8jZ59QZABAHgwX3vlQYX+YyBuLQEAAAsjyAAAAMsiyAAAAMsiyAAAAMsiyAAAAMsiyACA1RQ6Ku8EznGsdDrQQBBkAMBKCh3SiuFS0qDy3fM7jpaOXzGcMIMGgyADAFbizJcKfir/rqHz30lU8FPpfEADQJABACuxX1X+XUMZW8q/k4jO4tBA0LMvAFjNv981ZCTdKdvJw9Jf+kuSjKatZDv/nUSwnOISQ1vTTyj3dKHCg3zVs3WovBrZzC7LoxFkAMCC1mV6aU3+I3pD/+Ua95/5j2hYppcSePWQJa3bk6U5H+9TlqPQNS7K7qtZgzspoXOUiZV5Nm4tAYDFrNuTpWdXbNBTzvlu459yztezKzZo3Z4scwpDta3bk6XxK3a4hRhJynYUavyKHRzTiyDIAICFFJcYWvzRV1rlPVctG+XqSEm4hjln60hJuFo2ytUq77la/NFXKi4xzC4VVVRcYmjOx/tU0RErGzfn430c00pwa6muFDokZ76Kg6LL3/88/ePFX0Vf3WWv5DvZTrbTzHqtdEzreDt37tmrhYUzXSHmvqKnlaUw3Vf0tFb/O9wsLJypnXuuVY+unS27nVfMQn9Gt6afUL7jhCJ1VtkKKzc9QseV7/DT1vQTimt7wXQLbWdtsUSQWbRokV566SVlZ2erW7duevXVV9WzZ0+zy6q6f/f7cOZktkace1rf5wW6JnULzteqJnPl3zRSGvV++YNf3WWv5DvZTrbTzHqtdExN2M5sZ2PZFCyVyBViJLmFmeMKVrazgr/eLbSdV8Rif0ZPnPhJb3k/rzDluR1TSYrScdcxzTrRRTo/yFhsO2uLx99aeueddzR16lTNmjVLO3bsULdu3TRgwADl5uaaXVrVOfN15mS2/AsytbBwpqJ0XFLpCbqwcKb8CzJ15mR2xf0+VHfZK/lOtpPtNLNeKx1TE7YzNLS5RhdN170X/OBJpWHm3qKnNbpoukJDm1t6O6+Ixf6MRvr8ojDlqWWjXK32nuu2bNlVtjDlKdLnF0tvZ23x+CDzyiuvaNy4cRo7dqw6deqk119/Xf7+/vrLX/5idmlVVhwUrRHnnnbdw17tPVfdbf90naBHSsI14tzTKg6KrrFlr+Q72U6208x6rXRMzdjOnq1DFWgPVU4FtyAkKUdhCrSHqmfrUEtv55Ww2p/R6zpfq8d9/3zRZR/3/bOu63ytpbeztnh0kCkqKlJaWpri4+Nd4xo1aqT4+HilpqZWuIzT6VReXp7bYLat6Sf0fV6g7iv69eCv8Zntdo/7+7xAbU0/UWPLXsl3sp1sp5n1WumYmrGdXo1smjW4kyTpwt5Fyj7PGtypwr5HrLSdV8Jqf0a9Gtk0/nd9NKKSZUcUPa3xv+tT7phabTtri0cHmZ9//lnFxcWKiIhwGx8REaHs7OwKl0lMTJTdbncNsbGxdVHqReWeLn2cLkthmnLuD27Tppz7g+vycNl8NbHslXxndbGd9Ws7zarXSsfUrO1M6BylxaO6K9Lu6zY+0u6rxaO6V9rniNW2s7qs+Gc0oXOUnhl1h57zmew2/jmfyXpm1B0VHlMrbmdt8OggUx0zZsyQw+FwDZmZmWaXpPCg0r9sonRc85q85jZtXpPXXPcYy+ariWWv5Duri+2sX9tpVr1WOqZmbmdC5yj9fdrtWjWutxbcd51Wjeutv0+7/aIdp1lxO6vDqn9GE2KLtSTwDbdxSwLfUEJscYXzW3U7a5pHB5lmzZrJy8tLOTk5buNzcnIUGRlZ4TI+Pj4KDg52G8zWs3WougXnu91DPL/fh9Xec9UtOL/Ce9rVXfZKvpPtZDvNrNdKx9Ts7fRqZFNc2zANue4qxbUNu2RX9lbdzstlyT+j/37pp63sfVkPfS41bVX6+fyXg1p9O2uBzTAMj+5hp1evXurZs6deffVVSVJJSYlatGihiRMnavr06ZdcPi8vT3a7XQ6Hw7xQ4zimM28MkH9BpuseYpbC3FqknwmIlf8j68u/6K26y17Jd7KdbKeZ9VrpmLKd9Ws7TdxHShp0wUs/Y9zfaN60lTTmb+Yflzo8nlX9/fboKzKSNHXqVC1dulRvvfWWfvjhB40fP14FBQUaO3as2aVVnU+g/JtG6kxArB73/bNbvw+P+/659KA3jSztRKimlr2S72Q72U4z67XSMWU769d2mriPFNDcPcRIrpeDqmmr0umecFzM+rvoIjz+iowk/c///I+rQ7zrrrtOCxcuVK9evaq0rEdckZEaTu+LbGf92k6z6rXSMWU769d2XsmyNfCdFV7FcBzzrONSR8ezqr/flggyV8JjggwAAKiyenNrCQAAoDIEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFkEGQAAYFmNzS6gtpV1XJyXl2dyJQAAoKrKfrcv9QKCeh9kTp8+LUmKjY01uRIAAHC5Tp8+Lbu98nc31ft3LZWUlOjHH39UUFCQbDZbja03Ly9PsbGxyszM5B1OlWAfXRr76NLYRxfH/rk09tGleeI+MgxDp0+fVnR0tBo1qrwlTL2/ItOoUSPFxMTU2vqDg4M95qB7KvbRpbGPLo19dHHsn0tjH12ap+2ji12JKUNjXwAAYFkEGQAAYFkEmWry8fHRrFmz5OPjY3YpHot9dGnso0tjH10c++fS2EeXZuV9VO8b+wIAgPqLKzIAAMCyCDIAAMCyCDIAAMCyCDIAAMCyCDLVtGjRIrVq1Uq+vr7q1auXtm7danZJHmP27Nmy2WxuQ8eOHc0uy1RfffWVBg8erOjoaNlsNn3wwQdu0w3D0DPPPKOoqCj5+fkpPj5eBw4cMKdYE1xq/4wZM6bcOZWQkGBOsSZJTEzUjTfeqKCgIIWHh2vo0KHav3+/2zyFhYWaMGGCwsLCFBgYqOHDhysnJ8ekiutWVfZP3759y51Hjz76qEkV173Fixera9eurk7v4uLi9Nlnn7mmW/X8IchUwzvvvKOpU6dq1qxZ2rFjh7p166YBAwYoNzfX7NI8xrXXXqusrCzX8Pe//93skkxVUFCgbt26adGiRRVOf/HFF7Vw4UK9/vrr2rJliwICAjRgwAAVFhbWcaXmuNT+kaSEhAS3c2rVqlV1WKH5UlJSNGHCBG3evFkbNmzQuXPn1L9/fxUUFLjmmTJlij7++GO9++67SklJ0Y8//qhhw4aZWHXdqcr+kaRx48a5nUcvvviiSRXXvZiYGD3//PNKS0vT9u3bdfvtt2vIkCHau3evJAufPwYuW8+ePY0JEya4PhcXFxvR0dFGYmKiiVV5jlmzZhndunUzuwyPJclYu3at63NJSYkRGRlpvPTSS65xp06dMnx8fIxVq1aZUKG5Ltw/hmEYo0ePNoYMGWJKPZ4qNzfXkGSkpKQYhlF6zjRp0sR49913XfP88MMPhiQjNTXVrDJNc+H+MQzDuPXWW41JkyaZV5QHatq0qfHmm29a+vzhisxlKioqUlpamuLj413jGjVqpPj4eKWmpppYmWc5cOCAoqOj1aZNG40cOVIZGRlml+Sx0tPTlZ2d7XZO2e129erVi3PqPMnJyQoPD1eHDh00fvx4HT9+3OySTOVwOCRJoaGhkqS0tDSdO3fO7Tzq2LGjWrRo0SDPowv3T5m3335bzZo1U+fOnTVjxgydOXPGjPJMV1xcrNWrV6ugoEBxcXGWPn/q/Usja9rPP/+s4uJiRUREuI2PiIjQP/7xD5Oq8iy9evVSUlKSOnTooKysLM2ZM0e33HKL9uzZo6CgILPL8zjZ2dmSVOE5VTatoUtISNCwYcPUunVrHTp0SP/1X/+lgQMHKjU1VV5eXmaXV+dKSko0efJk3XTTTercubOk0vPI29tbISEhbvM2xPOoov0jSffff79atmyp6Oho7dq1S9OmTdP+/fu1Zs0aE6utW7t371ZcXJwKCwsVGBiotWvXqlOnTtq5c6dlzx+CDGrcwIEDXf/ftWtX9erVSy1bttRf//pXPfzwwyZWBqu67777XP/fpUsXde3aVW3btlVycrL69etnYmXmmDBhgvbs2dPg255VprL988gjj7j+v0uXLoqKilK/fv106NAhtW3btq7LNEWHDh20c+dOORwOvffeexo9erRSUlLMLuuKcGvpMjVr1kxeXl7lWnLn5OQoMjLSpKo8W0hIiNq3b6+DBw+aXYpHKjtvOKeqrk2bNmrWrFmDPKcmTpyoTz75RJs2bVJMTIxrfGRkpIqKinTq1Cm3+RvaeVTZ/qlIr169JKlBnUfe3t5q166devToocTERHXr1k0LFiyw9PlDkLlM3t7e6tGjhzZu3OgaV1JSoo0bNyouLs7EyjxXfn6+Dh06pKioKLNL8UitW7dWZGSk2zmVl5enLVu2cE5V4ujRozp+/HiDOqcMw9DEiRO1du1affnll2rdurXb9B49eqhJkyZu59H+/fuVkZHRIM6jS+2fiuzcuVOSGtR5dKGSkhI5nU5rnz9mtza2otWrVxs+Pj5GUlKSsW/fPuORRx4xQkJCjOzsbLNL8whPPPGEkZycbKSnpxvffPONER8fbzRr1szIzc01uzTTnD592vjuu++M7777zpBkvPLKK8Z3331nHDlyxDAMw3j++eeNkJAQ48MPPzR27dplDBkyxGjdurVx9uxZkyuvGxfbP6dPnzb++Mc/GqmpqUZ6errxxRdfGN27dzeuvvpqo7Cw0OzS68z48eMNu91uJCcnG1lZWa7hzJkzrnkeffRRo0WLFsaXX35pbN++3YiLizPi4uJMrLruXGr/HDx40Hj22WeN7du3G+np6caHH35otGnTxujTp4/Jlded6dOnGykpKUZ6erqxa9cuY/r06YbNZjM+//xzwzCse/4QZKrp1VdfNVq0aGF4e3sbPXv2NDZv3mx2SR7j3nvvNaKiogxvb2/jqquuMu69917j4MGDZpdlqk2bNhmSyg2jR482DKP0Eeynn37aiIiIMHx8fIx+/foZ+/fvN7foOnSx/XPmzBmjf//+RvPmzY0mTZoYLVu2NMaNG9fg/uFQ0f6RZCxbtsw1z9mzZ40//OEPRtOmTQ1/f3/jrrvuMrKysswrug5dav9kZGQYffr0MUJDQw0fHx+jXbt2xp/+9CfD4XCYW3gdeuihh4yWLVsa3t7eRvPmzY1+/fq5QoxhWPf8sRmGYdTd9R8AAICaQxsZAABgWQQZAABgWQQZAABgWQQZAABgWQQZAABgWQQZAABgWQQZAABgWQQZAABgWQQZAKZKSkpSSEiI2WUAsCiCDIBKjRkzRjabzTWEhYUpISFBu3btqrHvuPfee/XPf/6zxtZ3vlatWmn+/PmXvVzfvn01efLkGq8HQM0jyAC4qISEBGVlZSkrK0sbN25U48aN9dvf/rbG1u/n56fw8PAaWx+AhoUgA+CifHx8FBkZqcjISF133XWaPn26MjMz9dNPP7nmmTZtmtq3by9/f3+1adNGTz/9tM6dO+ea/v333+u2225TUFCQgoOD1aNHD23fvl1S+VtLF5v3QoZhaPbs2WrRooV8fHwUHR2txx9/XFLpVZUjR45oypQpritKknT8+HGNGDFCV111lfz9/dWlSxetWrXKtc4xY8YoJSVFCxYscC13+PBhSdKePXs0cOBABQYGKiIiQg888IB+/vln17LvvfeeunTpIj8/P4WFhSk+Pl4FBQVXdgAAXBRBBkCV5efna8WKFWrXrp3CwsJc44OCgpSUlKR9+/ZpwYIFWrp0qebNm+eaPnLkSMXExGjbtm1KS0vT9OnT1aRJkwq/43Lmff/99zVv3jwtWbJEBw4c0AcffKAuXbpIktasWaOYmBg9++yzritKklRYWKgePXro008/1Z49e/TII4/ogQce0NatWyVJCxYsUFxcnMaNG+daLjY2VqdOndLtt9+u66+/Xtu3b9e6deuUk5Oje+65R5KUlZWlESNG6KGHHtIPP/yg5ORkDRs2TLyXF6hl5r58G4AnGz16tOHl5WUEBAQYAQEBhiQjKirKSEtLu+hyL730ktGjRw/X56CgICMpKanCeZctW2bY7fYqzXuhl19+2Wjfvr1RVFRU4fSWLVsa8+bNu+R67rzzTuOJJ55wfb711luNSZMmuc0zd+5co3///m7jMjMzDUnG/v37jbS0NEOScfjw4SrVDqBmcEUGwEXddttt2rlzp3bu3KmtW7dqwIABGjhwoI4cOeKa55133tFNN92kyMhIBQYGaubMmcrIyHBNnzp1qv7jP/5D8fHxev7553Xo0KFKv+9y5r377rt19uxZtWnTRuPGjdPatWv1yy+/XHR7iouLNXfuXHXp0kWhoaEKDAzU+vXr3eqtyPfff69NmzYpMDDQNXTs2FGSdOjQIXXr1k39+vVTly5ddPfdd2vp0qU6efLkRdcJ4MoRZABcVEBAgNq1a6d27drpxhtv1JtvvqmCggItXbpUkpSamqqRI0dq0KBB+uSTT/Tdd9/pqaeeUlFRkWsds2fP1t69e3XnnXfqyy+/VKdOnbR27doKv+9y5o2NjdX+/fv12muvyc/PT3/4wx/Up08ft/Y5F3rppZe0YMECTZs2TZs2bdLOnTs1YMAAt3orkp+fr8GDB7tCXdlw4MAB9enTR15eXtqwYYM+++wzderUSa+++qo6dOig9PT0S+1iAFeAIAPgsthsNjVq1Ehnz56VJH377bdq2bKlnnrqKd1www26+uqr3a7WlGnfvr2mTJmizz//XMOGDdOyZcsq/Y7LmdfPz0+DBw/WwoULlZycrNTUVO3evVuS5O3treLiYrf5v/nmGw0ZMkSjRo1St27d1KZNm3KPf1e0XPfu3bV37161atXKFezKhoCAANe+uemmmzRnzhx999138vb2rjSEAagZBBkAF+V0OpWdna3s7Gz98MMPeuyxx1xXJyTp6quvVkZGhlavXq1Dhw5p4cKFbj/eZ8+e1cSJE5WcnKwjR47om2++0bZt23TNNdeU+67LmVcqfeLpf//3f7Vnzx7961//0ooVK+Tn56eWLVtKKu1H5quvvtKxY8dcTxddffXV2rBhg7799lv98MMP+s///E/l5OS4rbdVq1basmWLDh8+rJ9//lklJSWaMGGCTpw4oREjRmjbtm06dOiQ1q9fr7Fjx6q4uFhbtmzRf//3f2v79u3KyMjQmjVr9NNPP1VaO4AaYnYjHQCea/To0YYk1xAUFGTceOONxnvvvec235/+9CcjLCzMCAwMNO69915j3rx5rga8TqfTuO+++4zY2FjD29vbiI6ONiZOnGicPXvWMAz3xr6XmvdCa9euNXr16mUEBwcbAQEBRu/evY0vvvjCNT01NdXo2rWr4ePjY5T9dXf8+HFjyJAhRmBgoBEeHm7MnDnTePDBB40hQ4a4ltu/f7/Ru3dvw8/Pz5BkpKenG4ZhGP/85z+Nu+66ywgJCTH8/PyMjh07GpMnTzZKSkqMffv2GQMGDDCaN29u+Pj4GO3btzdeffXVGjgKAC7GZhg8GwgAAKyJW0sAAMCyCDIAAMCyCDIAAMCyCDIAAMCyCDIAAMCyCDIAAMCyCDIAAMCyCDIAAMCyCDIAAMCyCDIAAMCyCDIAAMCy/j+6quX6igBkOwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "n_samples = 100\n",
+    "n_qubits = len(my_circ.qubits)\n",
+    "\n",
+    "# Initialise the sample counter\n",
+    "sample_count = [0 for _ in range(2**n_qubits)]\n",
+    "\n",
+    "with CuTensorNetHandle() as libhandle:\n",
+    "    my_mps.update_libhandle(libhandle)\n",
+    "    \n",
+    "    for _ in range(n_samples):\n",
+    "        # Draw a sample\n",
+    "        qubit_outcomes = my_mps.sample()\n",
+    "        # Convert qubit outcomes to bitstring\n",
+    "        bitstring = \"\".join(str(qubit_outcomes[q]) for q in my_circ.qubits)\n",
+    "        # Convert bitstring to int\n",
+    "        outcome = int(bitstring, 2)\n",
+    "        # Update the sample dictionary\n",
+    "        sample_count[outcome] += 1\n",
+    "        \n",
+    "# Calculate the theoretical number of samples per bitstring\n",
+    "expected_count = [n_samples*abs(state_vector[i])**2 for i in range(2**n_qubits)]\n",
+    "        \n",
+    "# Plot a comparison of theory vs sampled\n",
+    "plt.scatter(range(2**n_qubits), expected_count, label=\"Theory\")\n",
+    "plt.scatter(range(2**n_qubits), sample_count, label=\"Experiment\", marker='x')\n",
+    "plt.xlabel(\"Basis states\")\n",
+    "plt.ylabel(\"Samples\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58d7a2c7-a2e8-4bd9-b55e-a8701aea4ea6",
+   "metadata": {},
+   "source": [
+    "We also provide methods to apply mid-circuit measurements via `my_mps.measure(qubits)` and postselection via `my_mps.postselect(qubit_outcomes)`. Their use is similar to that of `my_mps.sample()` shown above.\n",
+    "\n",
+    "**Note:** whereas `my_mps.sample()` does *not* change the state of the MPS, `my_mps.measure(qubits)` and `my_mps.postselect(qubit_outcomes)` do change it, projecting the state to the resulting outcome and removing the measured qubits."
    ]
   },
   {
@@ -277,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "e6edc6a9-0e31-4e45-b444-55c0790ca642",
    "metadata": {},
    "outputs": [
@@ -309,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "b3db8b6d-424e-405d-94ce-deebc481dac0",
    "metadata": {},
    "outputs": [],
@@ -336,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "3a079908-dd3a-4b75-b3ac-5d150b9513f7",
    "metadata": {},
    "outputs": [
@@ -373,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "349158fd-f88a-4262-9e46-741c1225939d",
    "metadata": {},
    "outputs": [
@@ -402,7 +473,7 @@
        "\n",
        "\n",
        "\n",
-       "    &lt;div id=&#34;circuit-display-vue-container-7383db6e-1623-4936-94f4-42a52930c17e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-827efb1f-a27d-49d8-83f1-beb6c80c4a56&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
        "        &lt;div style=&#34;display: none&#34;&gt;\n",
        "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [2]], [&#34;q&#34;, [3]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;ZZPhase&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.8&#34;], &#34;type&#34;: &#34;Ry&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [3]], [&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.7&#34;], &#34;type&#34;: &#34;XXPhase&#34;}}, {&#34;args&#34;: [[&#34;q&#34;, [1]], [&#34;q&#34;, [4]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.1&#34;, &#34;0.2&#34;, &#34;0.4&#34;], &#34;type&#34;: &#34;TK2&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;q&#34;, [0]], [&#34;q&#34;, [0]]], [[&#34;q&#34;, [1]], [&#34;q&#34;, [1]]], [[&#34;q&#34;, [2]], [&#34;q&#34;, [2]]], [[&#34;q&#34;, [3]], [&#34;q&#34;, [3]]], [[&#34;q&#34;, [4]], [&#34;q&#34;, [4]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;q&#34;, [0]], [&#34;q&#34;, [1]], [&#34;q&#34;, [2]], [&#34;q&#34;, [3]], [&#34;q&#34;, [4]]]}&lt;/div&gt;\n",
        "        &lt;/div&gt;\n",
@@ -412,7 +483,7 @@
        "        &gt;&lt;/circuit-display-container&gt;\n",
        "    &lt;/div&gt;\n",
        "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
-       "      const circuitRendererUid = &#34;7383db6e-1623-4936-94f4-42a52930c17e&#34;;\n",
+       "      const circuitRendererUid = &#34;827efb1f-a27d-49d8-83f1-beb6c80c4a56&#34;;\n",
        "      const displayOptions = JSON.parse(&#39;{}&#39;);\n",
        "\n",
        "      // Script to initialise the circuit renderer app\n",
@@ -471,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "181ea39a-d3c2-427c-91e7-7802a2eef94e",
    "metadata": {},
    "outputs": [
@@ -501,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "a3229854-049f-4307-a7f9-73d58d968c16",
    "metadata": {},
    "outputs": [
@@ -530,7 +601,7 @@
        "\n",
        "\n",
        "\n",
-       "    &lt;div id=&#34;circuit-display-vue-container-4bee7c61-c149-47ac-9c11-ebe151fa24f3&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
+       "    &lt;div id=&#34;circuit-display-vue-container-63c69977-1f18-4780-a1c9-c5ffc874f18e&#34; class=&#34;pytket-circuit-display-container&#34;&gt;\n",
        "        &lt;div style=&#34;display: none&#34;&gt;\n",
        "            &lt;div id=&#34;circuit-json-to-display&#34;&gt;{&#34;bits&#34;: [], &#34;commands&#34;: [{&#34;args&#34;: [[&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.8&#34;], &#34;type&#34;: &#34;Ry&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;H&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [0]], [&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;SWAP&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [4]], [&#34;node&#34;, [3]]], &#34;op&#34;: {&#34;type&#34;: &#34;CX&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [2]], [&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.3&#34;], &#34;type&#34;: &#34;ZZPhase&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [1]], [&#34;node&#34;, [0]]], &#34;op&#34;: {&#34;type&#34;: &#34;CZ&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [3]], [&#34;node&#34;, [2]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.7&#34;], &#34;type&#34;: &#34;XXPhase&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [3]], [&#34;node&#34;, [2]]], &#34;op&#34;: {&#34;type&#34;: &#34;SWAP&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [2]], [&#34;node&#34;, [1]]], &#34;op&#34;: {&#34;type&#34;: &#34;SWAP&#34;}}, {&#34;args&#34;: [[&#34;node&#34;, [1]], [&#34;node&#34;, [0]]], &#34;op&#34;: {&#34;params&#34;: [&#34;0.1&#34;, &#34;0.2&#34;, &#34;0.4&#34;], &#34;type&#34;: &#34;TK2&#34;}}], &#34;created_qubits&#34;: [], &#34;discarded_qubits&#34;: [], &#34;implicit_permutation&#34;: [[[&#34;node&#34;, [0]], [&#34;node&#34;, [0]]], [[&#34;node&#34;, [1]], [&#34;node&#34;, [1]]], [[&#34;node&#34;, [2]], [&#34;node&#34;, [2]]], [[&#34;node&#34;, [3]], [&#34;node&#34;, [3]]], [[&#34;node&#34;, [4]], [&#34;node&#34;, [4]]]], &#34;phase&#34;: &#34;0.0&#34;, &#34;qubits&#34;: [[&#34;node&#34;, [0]], [&#34;node&#34;, [1]], [&#34;node&#34;, [2]], [&#34;node&#34;, [3]], [&#34;node&#34;, [4]]]}&lt;/div&gt;\n",
        "        &lt;/div&gt;\n",
@@ -540,7 +611,7 @@
        "        &gt;&lt;/circuit-display-container&gt;\n",
        "    &lt;/div&gt;\n",
        "    &lt;script type=&#34;application/javascript&#34;&gt;\n",
-       "      const circuitRendererUid = &#34;4bee7c61-c149-47ac-9c11-ebe151fa24f3&#34;;\n",
+       "      const circuitRendererUid = &#34;63c69977-1f18-4780-a1c9-c5ffc874f18e&#34;;\n",
        "      const displayOptions = JSON.parse(&#39;{}&#39;);\n",
        "\n",
        "      // Script to initialise the circuit renderer app\n",
@@ -608,7 +679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "af2c2dc7-0c22-4805-8181-81d044b1033e",
    "metadata": {},
    "outputs": [
@@ -645,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "4c536376-0259-406e-8a3a-98940fd227a8",
    "metadata": {},
    "outputs": [],
@@ -676,7 +747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "1e5c57c8-0089-4433-8d70-8e0b7975a0b5",
    "metadata": {},
    "outputs": [],
@@ -694,7 +765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "250a3ac6-0777-4d68-a573-96f4a98e9b28",
    "metadata": {},
    "outputs": [
@@ -703,10 +774,10 @@
      "output_type": "stream",
      "text": [
       "Time taken by approximate contraction with bound chi:\n",
-      "1.51 seconds\n",
+      "4.64 seconds\n",
       "\n",
       "Lower bound of the fidelity:\n",
-      "0.2402\n"
+      "0.3834\n"
      ]
     }
    ],
@@ -731,7 +802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "3803bdf2-77c0-4a60-8afe-4933ea3ab75c",
    "metadata": {},
    "outputs": [
@@ -740,17 +811,17 @@
      "output_type": "stream",
      "text": [
       "Time taken by approximate contraction with fixed truncation fidelity:\n",
-      "1.55 seconds\n",
+      "10.03 seconds\n",
       "\n",
       "Lower bound of the fidelity:\n",
-      "0.4611\n"
+      "0.9367\n"
      ]
     }
    ],
    "source": [
     "start = time()\n",
     "with CuTensorNetHandle() as libhandle:\n",
-    "    fixed_fidelity_mps = simulate(libhandle, circuit, ContractionAlg.MPSxGate, truncation_fidelity=0.99)\n",
+    "    fixed_fidelity_mps = simulate(libhandle, circuit, ContractionAlg.MPSxGate, truncation_fidelity=0.999)\n",
     "end = time()\n",
     "print(\"Time taken by approximate contraction with fixed truncation fidelity:\")\n",
     "print(f\"{round(end-start,2)} seconds\")\n",
@@ -786,7 +857,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "13f6cf39-2228-4165-9fae-1ba36afb54b4",
    "metadata": {},
    "outputs": [
@@ -795,8 +866,8 @@
      "output_type": "stream",
      "text": [
       "MPSxGate\n",
-      "\tTime taken: 1.14 seconds\n",
-      "\tLower bound of the fidelity: 0.2408\n"
+      "\tTime taken: 4.71 seconds\n",
+      "\tLower bound of the fidelity: 0.3834\n"
      ]
     }
    ],
@@ -812,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "d11cb199-fb17-4b56-917f-b090ac25a886",
    "metadata": {},
    "outputs": [
@@ -821,8 +892,8 @@
      "output_type": "stream",
      "text": [
       "MPSxMPO, default parameters\n",
-      "\tTime taken: 12.49 seconds\n",
-      "\tLower bound of the fidelity: 0.301\n"
+      "\tTime taken: 22.58 seconds\n",
+      "\tLower bound of the fidelity: 0.4275\n"
      ]
     }
    ],
@@ -838,7 +909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "7eb19f55-0a1d-48ef-896c-0f679cf441d1",
    "metadata": {},
    "outputs": [
@@ -847,8 +918,8 @@
      "output_type": "stream",
      "text": [
       "MPSxMPO, custom parameters\n",
-      "\tTime taken: 27.98 seconds\n",
-      "\tLower bound of the fidelity: 0.3638\n"
+      "\tTime taken: 31.27 seconds\n",
+      "\tLower bound of the fidelity: 0.4603\n"
      ]
     }
    ],
@@ -873,9 +944,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py-cuquantum-23.06.0-mypich-py3.9",
    "language": "python",
-   "name": "python3"
+   "name": "py-cuquantum-23.06.0-mypich-py3.9"
   },
   "language_info": {
    "codemirror_mode": {

--- a/pytket/extensions/cutensornet/mps/__init__.py
+++ b/pytket/extensions/cutensornet/mps/__init__.py
@@ -33,4 +33,4 @@ from .mps_mpo import (
     MPSxMPO,
 )
 
-from .simulation import ContractionAlg, simulate, get_amplitude, prepare_circuit
+from .simulation import ContractionAlg, simulate, prepare_circuit

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -388,13 +388,19 @@ class MPS:
         Args:
             other: The other MPS to compare against.
 
+        Returns:
+            The resulting complex number.
+
         Raises:
             RuntimeError: If number of tensors, dimensions or positions do not match.
             RuntimeError: If there are no tensors in the MPS.
-
-        Return:
-            The resulting complex number.
+            RuntimeError: If the ``CuTensorNetHandle`` is out of scope.
         """
+        if self._lib._is_destroyed:
+            raise RuntimeError(
+                "The cuTensorNet library handle is out of scope.",
+                "See the documentation of update_libhandle and CuTensorNetHandle.",
+            )
 
         if len(self) != len(other):
             raise RuntimeError("Number of tensors do not match.")

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -511,7 +511,7 @@ class MPS:
             # if we were to take all of the other tensors into account.
             prob = cq.contract(
                 "lrp,lrP,p,P->",  # No open bonds remain; this is just a scalar
-                self.tensors[pos],
+                self.tensors[pos].conj(),
                 self.tensors[pos],
                 zero_tensor,
                 zero_tensor,

--- a/pytket/extensions/cutensornet/mps/mps.py
+++ b/pytket/extensions/cutensornet/mps/mps.py
@@ -457,6 +457,10 @@ class MPS:
         Returns:
             A dictionary mapping each of the qubits in the MPS to their 0 or 1 outcome.
         """
+
+        # TODO: Copying is not strictly necessary, but to avoid it we would need to
+        # modify the algorithm in `measure`. This may be done eventually if `copy`
+        # is shown to be a bottleneck when sampling (which is likely).
         mps = self.copy()
         return mps.measure(mps.get_qubits())
 
@@ -631,14 +635,14 @@ class MPS:
         del self.canonical_form[len(self) - 1]
         self.tensors.pop(pos)
 
-    def expected_value(self, pauli_string: QubitPauliString) -> float:
-        """Obtains the expected value of the Pauli string observable.
+    def expectation_value(self, pauli_string: QubitPauliString) -> float:
+        """Obtains the expectation value of the Pauli string observable.
 
         Args:
-            pauli_string: A dictionary of qubits to Pauli observables.
+            pauli_string: A pytket object representing a tensor product of Paulis.
 
         Returns:
-            The expected value.
+            The expectation value.
 
         Raises:
             ValueError: If a key in ``pauli_string`` is not a qubit in the MPS.

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -433,7 +433,7 @@ def test_postselect_circ(circuit: Circuit, postselect_dict: dict) -> None:
 def test_expectation_value(circuit: Circuit, observable: QubitPauliString) -> None:
     pauli_to_optype = {Pauli.Z: OpType.Z, Pauli.Y: OpType.Z, Pauli.X: OpType.X}
 
-    # Use pytket to generate the expected value of the observable
+    # Use pytket to generate the expectation value of the observable
     ket_circ = circuit.copy()
     for q, o in observable.map.items():
         ket_circ.add_gate(pauli_to_optype[o], [q])
@@ -441,13 +441,13 @@ def test_expectation_value(circuit: Circuit, observable: QubitPauliString) -> No
 
     bra_sv = circuit.get_statevector()
 
-    expected_value = bra_sv.conj() @ ket_sv
+    expectation_value = bra_sv.conj() @ ket_sv
 
-    # Simulate the circuit and obtain the expected value
+    # Simulate the circuit and obtain the expectation value
     with CuTensorNetHandle() as libhandle:
         mps = simulate(libhandle, circuit, ContractionAlg.MPSxGate)
         assert np.isclose(
-            mps.expected_value(observable), expected_value, atol=mps._atol
+            mps.expectation_value(observable), expectation_value, atol=mps._atol
         )
 
 


### PR DESCRIPTION
This PR adds the following features:

- The `measure` method from `MPS` allows us to sample measurement outcomes in the Z basis from subsets of qubits in the state. The MPS then becomes the corresponding MPS on the rest of the qubits after projection.
- The `sample` measure encapsulates the case above when all qubits are being measured.
- The `postselect` method from `MPS` allows us to project MPS states to a subspace where certain qubits have been given a particular Z basis state. It also returns the probability of such postselection.
- The `get_statevector` method returns the statevector of the MPS, with qubits sorted following ILO
  - I've also moved `get_amplitude` to be an MPS method, I feel it belongs there.
- The `expectation_value` method calculates the expectation value of a given Pauli string.
