### PR TITLE
Docs/update menu links

### DIFF
--- a/.github/workflows/docs/build-docs
+++ b/.github/workflows/docs/build-docs
@@ -10,8 +10,11 @@ import sys
 
 DOCS_DIR = Path(sys.argv[0]).absolute().parent
 MODULES_DIR = DOCS_DIR.parent.parent.parent
-PYTKET_DOCS_LINK = "https://cqcl.github.io/tket/pytket/api/index.html"
-PYTKET_EX_DOCS_LINK = "https://cqcl.github.io/pytket-extensions/api/index.html"
+TKET_EXAMPLES_LINK = "https://tket.quantinuum.com/examples/"
+TKET_MANUAL_LINK = "https://tket.quantinuum.com/user-manual/"
+TKET_WEBSITE_LINK = "https://tket.quantinuum.com/"
+PYTKET_DOCS_LINK = "https://tket.quantinuum.com/api-docs/"
+PYTKET_EX_DOCS_LINK = "https://tket.quantinuum.com/api-docs/extensions.html"
 PYTKET_QULACS_PYPI_LINK = "https://pypi.org/project/pytket-cutensornet/"
 PYTKET_QULACS_GITHUB = "https://github.com/CQCL/pytket-cutensornet"
 MODULE = "cutensornet"
@@ -49,10 +52,13 @@ def build_module_docs():
     with open(mod_docs / "intro.txt", "r") as f:
         content = f.readlines()
         content.append(
-            "\n.. toctree::\n\t:caption: More documentation:\n\t:maxdepth: 1\n\n"
+            "\n.. toctree::\n\t:caption: pytket documentation:\n\t:maxdepth: 1\n\n"
         )
-        content.append(f"\tpytket <{PYTKET_DOCS_LINK}>\n")
+        content.append(f"\tpytket API docs <{PYTKET_DOCS_LINK}>\n")
         content.append(f"\tpytket extensions <{PYTKET_EX_DOCS_LINK}>\n")
+        content.append(f"\tManual <{TKET_MANUAL_LINK}>\n")
+        content.append(f"\tExample notebooks <{TKET_EXAMPLES_LINK}>\n")
+        content.append(f"\tTKET website <{TKET_WEBSITE_LINK}>\n")
         content.append(
             "\n.. toctree::\n\t:caption: Links:\n\t:maxdepth: 1\n\n"
         )

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ or `Hopper` GPU and first install `cuQuantum Python` following their installatio
 This will include the necessary dependencies such as CUDA toolkit. Then, to install
 `pytket-cutensornet`, run:
 
-```pip install pytket-cutensornet```
+```shell
+pip install pytket-cutensornet
+```
 
 ## Bugs, support and feature requests
 


### PR DESCRIPTION
Hi,

we would like to do some changes to the documentation to have a similar menu on the side on all extensions, see for example https://github.com/CQCL/pytket-stim/pull/36