### PR TITLE
TTN replace KL (NetworkX) with KaHyPar

### DIFF
--- a/pytket/extensions/cutensornet/__init__.py
+++ b/pytket/extensions/cutensornet/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/backends/__init__.py
+++ b/pytket/extensions/cutensornet/backends/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/general.py
+++ b/pytket/extensions/cutensornet/general.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/tnstate/__init__.py
+++ b/pytket/extensions/cutensornet/tnstate/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/tnstate/cut_rKaHyPar_sea20.ini
+++ b/pytket/extensions/cutensornet/tnstate/cut_rKaHyPar_sea20.ini
@@ -1,0 +1,64 @@
+# general
+mode=recursive
+objective=cut
+seed=-1
+cmaxnet=-1
+vcycles=0
+# main -> preprocessing -> min hash sparsifier
+p-use-sparsifier=true
+p-sparsifier-min-median-he-size=28
+p-sparsifier-max-hyperedge-size=1200
+p-sparsifier-max-cluster-size=10
+p-sparsifier-min-cluster-size=2
+p-sparsifier-num-hash-func=5
+p-sparsifier-combined-num-hash-func=100
+# main -> preprocessing -> community detection
+p-detect-communities=true
+p-detect-communities-in-ip=false
+p-reuse-communities=false
+p-max-louvain-pass-iterations=100
+p-min-eps-improvement=0.0001
+p-louvain-edge-weight=hybrid
+p-large-he-threshold=1000
+# main -> preprocessing -> large he removal
+p-smallest-maxnet-threshold=50000
+p-maxnet-removal-factor=0.01
+# main -> coarsening
+c-type=heavy_lazy
+c-s=3.25
+c-t=160
+# main -> coarsening -> rating
+c-rating-score=heavy_edge
+c-rating-use-communities=true
+c-rating-heavy_node_penalty=multiplicative
+c-rating-acceptance-criterion=best
+c-fixed-vertex-acceptance-criterion=free_vertex_only
+# main -> initial partitioning
+i-mode=direct
+i-technique=flat
+# initial partitioning -> initial partitioning
+i-algo=pool
+i-runs=20
+# initial partitioning -> bin packing
+i-bp-algorithm=worst_fit
+i-bp-heuristic-prepacking=false
+i-bp-early-restart=true
+i-bp-late-restart=true
+# initial partitioning -> local search
+i-r-type=twoway_fm
+i-r-runs=-1
+i-r-fm-stop=simple
+i-r-fm-stop-i=50
+# main -> local search
+r-type=twoway_fm_hyperflow_cutter
+r-runs=-1
+r-fm-stop=adaptive_opt
+r-fm-stop-alpha=1
+r-fm-stop-i=350
+# local_search -> flow scheduling and heuristics
+r-flow-execution-policy=exponential
+# local_search -> hyperflowcutter configuration
+r-hfc-size-constraint=mf-style
+r-hfc-scaling=16
+r-hfc-distance-based-piercing=true
+r-hfc-mbc=true

--- a/pytket/extensions/cutensornet/tnstate/general.py
+++ b/pytket/extensions/cutensornet/tnstate/general.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/tnstate/mps.py
+++ b/pytket/extensions/cutensornet/tnstate/mps.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/tnstate/mps_gate.py
+++ b/pytket/extensions/cutensornet/tnstate/mps_gate.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/tnstate/mps_mpo.py
+++ b/pytket/extensions/cutensornet/tnstate/mps_mpo.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/tnstate/simulation.py
+++ b/pytket/extensions/cutensornet/tnstate/simulation.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/tnstate/ttn.py
+++ b/pytket/extensions/cutensornet/tnstate/ttn.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/extensions/cutensornet/tnstate/ttn_gate.py
+++ b/pytket/extensions/cutensornet/tnstate/ttn_gate.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Quantinuum
+# Copyright 2019-2024 Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.11"],
+    install_requires=["pytket ~= 1.11", "kahypar ~= 1.3.5"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/tests/test_tnstate.py
+++ b/tests/test_tnstate.py
@@ -487,7 +487,7 @@ def test_circ_approx_explicit_ttn(circuit: Circuit) -> None:
         ttn_gate = simulate(libhandle, circuit, SimulationAlgorithm.TTNxGate, cfg)
         for g in circuit.get_commands():
             ttn_gate.apply_gate(g)
-        assert np.isclose(ttn_gate.get_fidelity(), 0.62, atol=1e-2)
+        assert np.isclose(ttn_gate.get_fidelity(), 0.64, atol=1e-2)
         assert ttn_gate.is_valid()
         assert np.isclose(ttn_gate.vdot(ttn_gate), 1.0, atol=cfg._atol)
 


### PR DESCRIPTION
Replacing the use of NetworkX KL partition algorithm (which is kind of bad) with KaHyPar partitioning. This partitioning is used to decide the way qubits are assigned to the different subtrees of the TTN, so that qubits that interact more are placed closer together. 

I have checked the performance of this against the version currently in feature/ttn using Henrik's circuits. In essence, the results are always better both in time and final fidelity and sometimes the difference is quite noticeable. For instance, a circuit run in similar time (13 and 12 seconds) but the fidelity was improved from 0.34 to 0.59. On another circuit, the fidelity was similar (~10^-5) while timing went down from 71s to 54s. In a bunch of circuits the difference was almost unnoticeable.
