### PR TITLE
Update python support to 3.10, 3.11 and 3.12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,22 +30,33 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-    - name: Build and mypy (3.9)
+        python-version: '3.10'
+    - name: Build and mypy (3.10)
       shell: bash
       if:  (matrix.os == 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
       run: |
         chmod +x ./.github/workflows/build-test
         ./.github/workflows/build-test mypy
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'schedule'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
-    - name: Build (3.10)
+        python-version: '3.11'
+    - name: Build (3.11)
+      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'schedule'
+      shell: bash
+      run: |
+        chmod +x ./.github/workflows/build-test
+        ./.github/workflows/build-test nomypy
+    - name: Set up Python 3.12
+      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'schedule'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Build (3.12)
       if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'schedule'
       shell: bash
       run: |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ implemented in the due course using `mpi4py` library.
 
 ## Getting started
 
-`pytket-cutensornet` is available for Python 3.9, 3.10 and 3.11 on Linux.
+`pytket-cutensornet` is available for Python 3.10, 3.11 and 3.12 on Linux.
 In order to use it, you need access to a Linux machine with an NVIDIA GPU of
 Compute Capability +7.0 (check it [here](https://developer.nvidia.com/cuda-gpus)) and first
 install `cuQuantum Python` following their installation

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+General:
+
+* Python 3.12 support added, 3.9 dropped.
+* Updated pytket version requirement to 1.24.
+
 0.5.3 (January 2024)
 --------------------
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -18,7 +18,7 @@ We provide two core functionalities:
 Currently, only single-GPU calculations are supported, but a multi-GPU execution will be
 implemented in the due course using ``mpi4py`` library.
 
-``pytket-cutensornet`` is available for Python 3.9, 3.10 and 3.11 on Linux.
+``pytket-cutensornet`` is available for Python 3.10, 3.11 and 3.12 on Linux.
 In order to use it, you need access to a Linux machine with an NVIDIA GPU of Compute Capability +7.0 (check it `here <https://developer.nvidia.com/cuda-gpus>`_) and first install ``cuQuantum Python`` following their installation
 `instructions  <https://docs.nvidia.com/cuda/cuquantum/latest/python/README.html#installation>`_.
 This will include the necessary dependencies such as CUDA toolkit. Then, to install

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 warn_unused_configs = True
 
 disallow_untyped_decorators = False

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.24.0rc0"],
+    install_requires=["pytket ~= 1.24"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     version=metadata["__extension_version__"],
     author="TKET development team",
     author_email="tket-support@cambridgequantum.com",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     project_urls={
         "Documentation": "https://tket.quantinuum.com/extensions/pytket-cutensornet/index.html",
         "Source": "https://github.com/CQCL/pytket-cutensornet",
@@ -42,12 +42,12 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.23"],
+    install_requires=["pytket ~= 1.24.0rc0"],
     classifiers=[
         "Environment :: Console",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR drops python 3.9 support and adds python 3.12, in line with `pytket` doing so.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
