### PR TITLE
Refactor TTN so that gates are applied without "funnel tensors"

### DIFF
--- a/pytket/extensions/cutensornet/tnstate/ttn_gate.py
+++ b/pytket/extensions/cutensornet/tnstate/ttn_gate.py
@@ -237,6 +237,11 @@ class TTNxGate(TTN):
             Q_bonds = "Lrs" if child_dir == DirTTN.LEFT else "lRs"
             R_bonds = "Bbsp"  # The new `msg_tensor`
 
+            self._logger.debug(
+                f"Pushing msg_tensor ({msg_tensor.nbytes // 2**20} MiB) through node "
+                f"({node.tensor.nbytes // 2**20} MiB) at {parent_bond}."
+            )
+
             # Apply the contraction followed by a QR decomposition
             node.tensor, msg_tensor = contract_decompose(
                 f"{node_bonds},{msg_bonds}->{Q_bonds},{R_bonds}",
@@ -260,6 +265,12 @@ class TTNxGate(TTN):
         msg_bonds = "BbLl" if child_dir == DirTTN.LEFT else "BbRr"
         Q_bonds = "Lsp" if child_dir == DirTTN.LEFT else "sRp"
         R_bonds = "Bbrs" if child_dir == DirTTN.LEFT else "Bbls"  # The new `msg_tensor`
+
+        self._logger.debug(
+            f"Pushing msg_tensor ({msg_tensor.nbytes // 2**20} MiB) through node "
+            f"({common_ancestor_node.tensor.nbytes // 2**20} MiB) at {parent_bond}."
+        )
+
 
         # Apply the contraction followed by a QR decomposition
         common_ancestor_node.tensor, msg_tensor = contract_decompose(
@@ -295,6 +306,11 @@ class TTNxGate(TTN):
             msg_bonds = "BbpP"
             Q_bonds = "srP" if child_dir == DirTTN.LEFT else "lsP"
             R_bonds = "Bbls" if child_dir == DirTTN.LEFT else "Bbrs"  # New `msg_tensor`
+
+            self._logger.debug(
+                f"Pushing msg_tensor ({msg_tensor.nbytes // 2**20} MiB) through node "
+                f"({node.tensor.nbytes // 2**20} MiB) at {parent_bond}."
+            )
 
             # Apply the contraction followed by a QR decomposition
             node.tensor, msg_tensor = contract_decompose(

--- a/pytket/extensions/cutensornet/tnstate/ttn_gate.py
+++ b/pytket/extensions/cutensornet/tnstate/ttn_gate.py
@@ -195,7 +195,9 @@ class TTNxGate(TTN):
 
         # We begin applying the gate to the TTN by contracting `gate_tensor` into the
         # leaf node containing `q0`, with the `b` and `B` bonds of the latter left open.
-        # We immediately QR-decompose the resulting tensor,
+        # We immediately QR-decompose the resulting tensor, so that Q becomes the new
+        # (canonicalised) leaf node and R becomes the `msg_tensor` that we will be
+        # "pushing" through the rest of the arc towards `q1`.
         leaf_node = self.nodes[path_q0]
         n_qbonds = len(leaf_node.tensor.shape) - 1  # Num of qubit bonds
         aux_bonds = [chr(x) for x in range(n_qbonds)]

--- a/pytket/extensions/cutensornet/tnstate/ttn_gate.py
+++ b/pytket/extensions/cutensornet/tnstate/ttn_gate.py
@@ -111,36 +111,35 @@ class TTNxGate(TTN):
         (path_q0, bond_q0) = self.qubit_position[q0]
         (path_q1, bond_q1) = self.qubit_position[q1]
 
+        # Glossary of bond IDs
+        # a -> the input bond of the gate on q0
+        # b -> the input bond of the gate on q1
+        # A -> the output bond of the gate on q0
+        # B -> the output bond of the gate on q1
+        # l -> left child bond of the TTN node
+        # r -> right child bond of the TTN node
+        # p -> the parent bond of the TTN node
+        # s -> the shared bond resulting from a decomposition
+        # chr(x) -> bond of the x-th qubit in a leaf node
+        gate_bonds = "ABab"
+
         # If the two qubits are in the same leaf node, contract the gate with it.
-        # There is no truncation needed.
+        # No truncation is required.
         if path_q0 == path_q1:
-            n_qbonds = (
-                len(self.nodes[path_q0].tensor.shape) - 1
-            )  # Total number of physical bonds in this node
-
-            # Glossary of bond IDs
-            # qX -> where X is the X-th physical bond (qubit) in the TTN node
-            # p  -> the parent bond of the TTN node
-            # i0 -> the input bond of the gate on q0
-            # o0 -> the output bond of the gate on q0
-            # i1 -> the input bond of the gate on q1
-            # o1 -> the output bond of the gate on q1
-            gate_bond = ["o0", "o1", "i0", "i1"]
-
-            aux_bonds = [f"q{x}" for x in range(n_qbonds)] + ["p"]
-            node_bonds = aux_bonds.copy()
-            node_bonds[bond_q0] = "i0"
-            node_bonds[bond_q1] = "i1"
-            result_bonds = aux_bonds
-            result_bonds[bond_q0] = "o0"
-            result_bonds[bond_q1] = "o1"
+            leaf_node = self.nodes[path_q0]
+            n_qbonds = len(leaf_node.tensor.shape) - 1  # Num of qubit bonds
+            aux_bonds = [chr(x) for x in range(n_qbonds)]
+            aux_bonds[bond_q0] = "a"
+            aux_bonds[bond_q1] = "b"
+            leaf_bonds = "".join(aux_bonds) + "p"
+            aux_bonds[bond_q0] = "A"
+            aux_bonds[bond_q1] = "B"
+            result_bonds = "".join(aux_bonds) + "p"
 
             self.nodes[path_q0].tensor = cq.contract(
-                self.nodes[path_q0].tensor,
-                node_bonds,
+                f"{leaf_bonds},{gate_bonds}->{result_bonds}",
+                leaf_node.tensor,
                 gate_tensor,
-                gate_bond,
-                result_bonds,
                 options=options,
                 optimize={"path": [(0, 1)]},
             )
@@ -172,23 +171,7 @@ class TTNxGate(TTN):
         #   be canonicalised ahead of time, but I don't expect the saving would be
         #   particularly noticeable, and it'd require some non-trivial refactoring
         #   of `canonicalise()`.
-        self.canonicalise(
-            center=(*common_path, DirTTN.LEFT)
-        )
-
-        self._logger.debug(f"Applying gate to the TTN.")
-
-        # Glossary of bond IDs
-        # a -> the input bond of the gate on q0
-        # b -> the input bond of the gate on q1
-        # A -> the output bond of the gate on q0
-        # B -> the output bond of the gate on q1
-        # l -> left child bond of the TTN node
-        # r -> right child bond of the TTN node
-        # p -> the parent bond of the TTN node
-        # s -> the shared bond resulting from a decomposition
-        # chr(x) -> bond of the x-th qubit in a leaf node
-        gate_bonds = "ABab"
+        self.canonicalise(center=(*common_path, DirTTN.LEFT))
 
         # The overall strategy is to connect the `a` bond of the gate tensor to
         # the corresponding bond for `q0` in the TTN (so that its bond `A`) becomes
@@ -215,14 +198,11 @@ class TTNxGate(TTN):
         # We immediately QR-decompose the resulting tensor,
         leaf_node = self.nodes[path_q0]
         n_qbonds = len(leaf_node.tensor.shape) - 1  # Num of qubit bonds
-        leaf_bonds = "".join(
-            "a" if x == bond_q0 else chr(x)
-            for x in range(n_qbonds)
-        ) + "p"
-        Q_bonds = "".join(
-            "A" if x == bond_q0 else chr(x)
-            for x in range(n_qbonds)
-        ) + "s"
+        aux_bonds = [chr(x) for x in range(n_qbonds)]
+        aux_bonds[bond_q0] = "a"
+        leaf_bonds = "".join(aux_bonds) + "p"
+        aux_bonds[bond_q0] = "A"
+        Q_bonds = "".join(aux_bonds) + "s"
         R_bonds = "Bbsp"  # The `msg_tensor`
 
         # Apply the contraction followed by a QR decomposition
@@ -230,7 +210,7 @@ class TTNxGate(TTN):
             f"{leaf_bonds},{gate_bonds}->{Q_bonds},{R_bonds}",
             leaf_node.tensor,
             gate_tensor,
-            algorithm={"qr_method": True},
+            algorithm={"qr_method": tensor.QRMethod()},
             options=options,
             optimize={"path": [(0, 1)]},
         )
@@ -239,13 +219,12 @@ class TTNxGate(TTN):
 
         # We must push the `msg_tensor` all the way to the common ancestor
         # of `q0` and `q1`.
-        bonds_from_q0_to_ancestor = [
+        bond_addresses = [
             path_q0[:i] for i in reversed(range(len(common_path) + 1, len(path_q0) + 1))
         ]
         # Sanity checks:
-        assert all(len(bond_addresses) != len(common_path))
+        assert all(len(root_path) != len(common_path) for root_path in bond_addresses)
         assert len(bond_addresses[0]) == len(path_q0)
-        assert len(bond_addresses[1]) < len(bond_addresses[0])
 
         # For all of these nodes; push `msg_tensor` through to their parent bond
         for child_bond in bond_addresses[:-1]:  # Doesn't do it on common ancestor!
@@ -263,7 +242,7 @@ class TTNxGate(TTN):
                 f"{node_bonds},{msg_bonds}->{Q_bonds},{R_bonds}",
                 node.tensor,
                 msg_tensor,
-                algorithm={"qr_method": True},
+                algorithm={"qr_method": tensor.QRMethod()},
                 options=options,
                 optimize={"path": [(0, 1)]},
             )
@@ -287,7 +266,7 @@ class TTNxGate(TTN):
             f"{node_bonds},{msg_bonds}->{Q_bonds},{R_bonds}",
             common_ancestor_node.tensor,
             msg_tensor,
-            algorithm={"qr_method": True},
+            algorithm={"qr_method": tensor.QRMethod()},
             options=options,
             optimize={"path": [(0, 1)]},
         )
@@ -299,13 +278,12 @@ class TTNxGate(TTN):
 
         # We must push the `msg_tensor` from the common ancestor to the leaf node
         # containing `q1`.
-        bonds_addresses = [
+        bond_addresses = [
             path_q1[:i] for i in range(len(common_path) + 1, len(path_q1) + 1)
         ]
         # Sanity checks:
-        assert all(len(bond_addresses) != len(common_path))
+        assert all(len(root_path) != len(common_path) for root_path in bond_addresses)
         assert len(bond_addresses[-1]) == len(path_q1)
-        assert len(bond_addresses[0]) < len(bond_addresses[1])
 
         # For all of these nodes; push `msg_tensor` through to their child bond
         for child_bond in bond_addresses[1:]:  # Skip common ancestor: already pushed
@@ -323,7 +301,7 @@ class TTNxGate(TTN):
                 f"{node_bonds},{msg_bonds}->{Q_bonds},{R_bonds}",
                 node.tensor,
                 msg_tensor,
-                algorithm={"qr_method": True},
+                algorithm={"qr_method": tensor.QRMethod()},
                 options=options,
                 optimize={"path": [(0, 1)]},
             )
@@ -334,23 +312,20 @@ class TTNxGate(TTN):
         # All we need to do is contract the `msg_tensor` into the leaf.
         leaf_node = self.nodes[path_q1]
         n_qbonds = len(leaf_node.tensor.shape) - 1  # Num of qubit bonds
-        leaf_bonds = "".join(
-            "b" if x == bond_q1 else chr(x)  # Connect `b` to `q1`
-            for x in range(n_qbonds)
-        ) + "p"
+        aux_bonds = [chr(x) for x in range(n_qbonds)]
+        aux_bonds[bond_q1] = "b"  # Connect `b` to `q1`
+        leaf_bonds = "".join(aux_bonds) + "p"
         msg_bonds = "BbpP"
-        result_bonds = "".join(
-            "B" if x == bond_q1 else chr(x)  # `B` becomes the new physical bond `q1`
-            for x in range(n_qbonds)
-        ) + "P"
+        aux_bonds[bond_q1] = "B"  # `B` becomes the new physical bond `q1`
+        result_bonds = "".join(aux_bonds) + "P"
 
         # Apply the contraction
         leaf_node.tensor = cq.contract(
             f"{leaf_bonds},{msg_bonds}->{result_bonds}",
             leaf_node.tensor,
-            msg_tensor
+            msg_tensor,
             options=options,
-            optimize={"path": [(1, 2), (0, 1)]},
+            optimize={"path": [(0, 1)]},
         )
         # The leaf node lost its canonical form
         leaf_node.canonical_form = None

--- a/tests/test_tnstate.py
+++ b/tests/test_tnstate.py
@@ -247,7 +247,7 @@ def test_exact_circ_sim(circuit: Circuit, algorithm: SimulationAlgorithm) -> Non
     state = circuit.get_statevector()
 
     with CuTensorNetHandle() as libhandle:
-        cfg = Config()
+        cfg = Config(leaf_size=2)
         tnstate = simulate(libhandle, circuit, algorithm, cfg)
         assert tnstate.is_valid()
         # Check that there was no approximation
@@ -306,7 +306,7 @@ def test_approx_circ_sim_gate_fid(
         circuit, _ = prepare_circuit_mps(circuit)
 
     with CuTensorNetHandle() as libhandle:
-        cfg = Config(truncation_fidelity=0.99)
+        cfg = Config(truncation_fidelity=0.99, leaf_size=2)
         tnstate = simulate(libhandle, circuit, algorithm, cfg)
         assert tnstate.is_valid()
         # Check that overlap is 1
@@ -351,7 +351,7 @@ def test_approx_circ_sim_chi(circuit: Circuit, algorithm: SimulationAlgorithm) -
         circuit, _ = prepare_circuit_mps(circuit)
 
     with CuTensorNetHandle() as libhandle:
-        cfg = Config(chi=4)
+        cfg = Config(chi=4, leaf_size=2)
         tnstate = simulate(libhandle, circuit, algorithm, cfg)
         assert tnstate.is_valid()
         # Check that overlap is 1
@@ -391,14 +391,18 @@ def test_float_point_options(
 
     with CuTensorNetHandle() as libhandle:
         # Exact
-        cfg = Config(float_precision=fp_precision)
+        cfg = Config(float_precision=fp_precision, leaf_size=2)
         tnstate = simulate(libhandle, circuit, algorithm, cfg)
         assert tnstate.is_valid()
         # Check that overlap is 1
         assert np.isclose(tnstate.vdot(tnstate), 1.0, atol=cfg._atol)
 
         # Approximate, bound truncation fidelity
-        cfg = Config(truncation_fidelity=0.99, float_precision=fp_precision)
+        cfg = Config(
+            truncation_fidelity=0.99,
+            float_precision=fp_precision,
+            leaf_size=2
+        )
         tnstate = simulate(
             libhandle,
             circuit,
@@ -410,7 +414,7 @@ def test_float_point_options(
         assert np.isclose(tnstate.vdot(tnstate), 1.0, atol=cfg._atol)
 
         # Approximate, bound chi
-        cfg = Config(chi=4, float_precision=fp_precision)
+        cfg = Config(chi=4, float_precision=fp_precision, leaf_size=2)
         tnstate = simulate(
             libhandle,
             circuit,
@@ -434,7 +438,7 @@ def test_circ_approx_explicit_mps(circuit: Circuit) -> None:
     with CuTensorNetHandle() as libhandle:
         # Finite gate fidelity
         # Check for MPSxGate
-        cfg = Config(truncation_fidelity=0.99)
+        cfg = Config(truncation_fidelity=0.99, leaf_size=4)
         mps_gate = simulate(
             libhandle,
             circuit,
@@ -458,7 +462,7 @@ def test_circ_approx_explicit_mps(circuit: Circuit) -> None:
 
         # Fixed virtual bond dimension
         # Check for MPSxGate
-        cfg = Config(chi=8)
+        cfg = Config(chi=8, leaf_size=4)
         mps_gate = simulate(libhandle, circuit, SimulationAlgorithm.MPSxGate, cfg)
         assert np.isclose(mps_gate.get_fidelity(), 0.03, atol=1e-2)
         assert mps_gate.is_valid()


### PR DESCRIPTION
# Description

Refactored `_apply_2q_gate` so that it does not apply funnel tensors (which were a major memory bottleneck). Instead, the gate is "pushed" through the TTN from the leaf contaning qubit `q0` to the leaf containing `q1` via consecutive applications of `contract_decompose`.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
