### PR TITLE
[feature] Always canonicalise MPS before 2q gate

### DIFF
--- a/pytket/extensions/cutensornet/structured_state/mps_gate.py
+++ b/pytket/extensions/cutensornet/structured_state/mps_gate.py
@@ -96,26 +96,15 @@ class MPSxGate(MPS):
         l_pos = min(positions)
         r_pos = max(positions)
 
+        # Always canonicalise. Even in the case of exact simulation (no truncation)
+        # canonicalisation may reduce the bond dimension (thanks to reduced QR).
+        self.canonicalise(l_pos, r_pos)
+
         # Figure out the new dimension of the shared virtual bond
         new_dim = 2 * min(
             self.get_virtual_dimensions(l_pos)[0],
             self.get_virtual_dimensions(r_pos)[1],
         )
-
-        # Canonicalisation may be required if `new_dim` is larger than `chi`
-        # or if set by `truncation_fidelity`
-        if new_dim > self._cfg.chi or self._cfg.truncation_fidelity < 1:
-            # If truncation required, convert to canonical form before
-            # contracting. Avoids the need to apply gauge transformations
-            # to the larger tensor resulting from the contraction.
-            self.canonicalise(l_pos, r_pos)
-
-            # Since canonicalisation may change the dimension of the bonds,
-            # we need to recalculate the value of `new_dim`
-            new_dim = 2 * min(
-                self.get_virtual_dimensions(l_pos)[0],
-                self.get_virtual_dimensions(r_pos)[1],
-            )
 
         # Load the gate's unitary to the GPU memory
         gate_unitary = gate.get_unitary().astype(dtype=self._cfg._complex_t, copy=False)


### PR DESCRIPTION
We used to only canonicalise MPS when there was going to be a truncation. However, some experiments using Mekena's use case have shown that canonicalising is also beneficial for exact simulation. In hindsight, this makes sense since canonicalisation will often reduce bond dimension (thanks to reduced QR decomposition) which will in most cases accelerate the simulation more than what the overhead of canonicalisation imposes.

# Checklist

- [x] I have run the tests on a machine with GPUs.
- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
