### PR TITLE
Bugfix/support create

### DIFF
--- a/pytket/extensions/cutensornet/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/tensor_network_convert.py
@@ -178,7 +178,7 @@ class TensorNetwork:
         self._input_nodes = []
         self._output_nodes = []
         for i, node in reversed(list(enumerate(self._network.nodes(data=True)))):
-            if node[1]["desc"] not in ("Input", "Output"):
+            if node[1]["desc"] not in ("Input", "Output", "Create"):
                 n_out_edges = len(list(self._network.out_edges(node[0])))
                 if n_out_edges > 1:
                     src_ports = [
@@ -213,7 +213,7 @@ class TensorNetwork:
             else:
                 if node[1]["desc"] == "Output":
                     self._output_nodes.append(i)
-                if node[1]["desc"] == "Input":
+                if node[1]["desc"] == "Input" or node[1]["desc"] == "Create":
                     self._input_nodes.append(i)
                     node_tensors.append(np.array([1, 0], dtype="complex128"))
         if adj:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,6 +186,24 @@ def q4_multicontrols() -> Circuit:
 
 
 @pytest.fixture
+def q4_with_creates() -> Circuit:
+    circuit = Circuit(4)
+    circuit.qubit_create_all()
+
+    circuit.S(1)
+    circuit.Rz(0.3, 0)
+    circuit.Ry(0.1, 2)
+    circuit.TK1(0.2, 0.9, 0.8, 3)
+    circuit.TK2(0.6, 0.5, 0.7, 1, 2)
+    circuit.X(0)
+    circuit.H(2)
+    circuit.V(1)
+    circuit.Z(3)
+
+    return circuit
+
+
+@pytest.fixture
 def q5_h0s1rz2ry3tk4tk13() -> Circuit:
     circuit = Circuit(5)
     circuit.H(0)

--- a/tests/test_cutensornet_backend.py
+++ b/tests/test_cutensornet_backend.py
@@ -111,6 +111,7 @@ def test_expectation_value() -> None:
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
         pytest.lazy_fixture("q4_lcu1"),  # type: ignore
         pytest.lazy_fixture("q4_multicontrols"),  # type: ignore
+        pytest.lazy_fixture("q4_with_creates"),  # type: ignore
     ],
 )
 def test_compile_convert_statevec_overlap(circuit: Circuit) -> None:

--- a/tests/test_structured_state.py
+++ b/tests/test_structured_state.py
@@ -225,6 +225,7 @@ def test_canonicalise_ttn(center: Union[RootPath, Qubit]) -> None:
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q4_with_creates"),  # type: ignore
         pytest.lazy_fixture("q5_h0s1rz2ry3tk4tk13"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
         pytest.lazy_fixture("q6_qvol"),  # type: ignore
@@ -286,6 +287,7 @@ def test_exact_circ_sim(circuit: Circuit, algorithm: SimulationAlgorithm) -> Non
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q4_with_creates"),  # type: ignore
         pytest.lazy_fixture("q5_h0s1rz2ry3tk4tk13"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
         pytest.lazy_fixture("q6_qvol"),  # type: ignore
@@ -333,6 +335,7 @@ def test_approx_circ_sim_gate_fid(
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q4_with_creates"),  # type: ignore
         pytest.lazy_fixture("q5_h0s1rz2ry3tk4tk13"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
         pytest.lazy_fixture("q6_qvol"),  # type: ignore
@@ -366,6 +369,7 @@ def test_approx_circ_sim_chi(circuit: Circuit, algorithm: SimulationAlgorithm) -
         pytest.lazy_fixture("q2_x0cx01cx10"),  # type: ignore
         pytest.lazy_fixture("q2_lcu2"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q4_with_creates"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
         pytest.lazy_fixture("q6_qvol"),  # type: ignore
     ],
@@ -585,6 +589,7 @@ def test_postselect_circ(circuit: Circuit, postselect_dict: dict) -> None:
         pytest.lazy_fixture("q2_lcu2"),  # type: ignore
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q4_with_creates"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
     ],
 )

--- a/tests/test_tensor_network_convert.py
+++ b/tests/test_tensor_network_convert.py
@@ -54,6 +54,7 @@ def circuit_overlap_contract(circuit_ket: Circuit) -> float:
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
         pytest.lazy_fixture("q4_lcu1"),  # type: ignore
         pytest.lazy_fixture("q4_multicontrols"),  # type: ignore
+        pytest.lazy_fixture("q4_with_creates"),  # type: ignore
     ],
 )
 def test_convert_statevec_overlap(circuit: Circuit) -> None:


### PR DESCRIPTION
# Description

The tensor network converter `TensorNetwork` did not support the `Create` operation that explicitly initialises a qubit to state |0>. This PR adds a bugfix and tests for this.

# Related issues

Bugfix for issue #88. 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
