### PR TITLE
[bugfix] CuTensorNetHandle failure on multiple GPUs after cuTensorNet 2.3.0

### DIFF
--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -54,7 +54,6 @@ class CuTensorNetHandle:
     """
 
     def __init__(self, device_id: Optional[int] = None):
-        self.handle = cutn.create()
         self._is_destroyed = False
 
         # Make sure CuPy uses the specified device
@@ -62,6 +61,8 @@ class CuTensorNetHandle:
 
         dev = cp.cuda.Device()
         self.device_id = int(dev)
+
+        self.handle = cutn.create()
 
     def __enter__(self) -> CuTensorNetHandle:
         return self


### PR DESCRIPTION
# Description

When running any simulation method that used the `CuTensorNetHandle` and with cuTensorNet>=2.3.0 installed, if you tried to use a GPU device that was not the default one (device=0) then you'd get a very obscure error.

It appears that the problem was caused due to newer versions of cuTensorNet make use of `cupy` internally, which needs its device being specified if not using the default one. We were already doing this anyway, but it turns out that the order of the commands was wrong, and `cutn.create()` which creates the cuTensorNet library handle was called _before_ updating the `cupy` device, causing a mismatch in the device being used.

# Checklist

- [x] I have run the tests on a machine with GPUs.
- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
