### PR TITLE
[bugfix] Default value of chi causes an error when state is copied

### DIFF
--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -128,14 +128,16 @@ class Config:
             ValueError: If the value of ``chi`` is set below 2.
             ValueError: If the value of ``truncation_fidelity`` is not in [0,1].
         """
+        _CHI_LIMIT = 2**60
         if (
             chi is not None
+            and chi < _CHI_LIMIT
             and truncation_fidelity is not None
             and truncation_fidelity != 1.0
         ):
             raise ValueError("Cannot fix both chi and truncation_fidelity.")
         if chi is None:
-            chi = 2**60  # In practice, this is like having it be unbounded
+            chi = _CHI_LIMIT  # In practice, this is like having it be unbounded
         if truncation_fidelity is None:
             truncation_fidelity = 1
 

--- a/tests/test_structured_state.py
+++ b/tests/test_structured_state.py
@@ -51,6 +51,44 @@ def test_init() -> None:
         assert ttn_gate.is_valid()
 
 
+@pytest.mark.parametrize(
+    "algorithm",
+    [
+        SimulationAlgorithm.MPSxGate,
+        SimulationAlgorithm.MPSxMPO,
+        SimulationAlgorithm.TTNxGate,
+    ],
+)
+def test_copy(algorithm: SimulationAlgorithm) -> None:
+    simple_circ = Circuit(2).H(0).H(1).CX(0, 1)
+
+    with CuTensorNetHandle() as libhandle:
+
+        # Default config
+        cfg = Config()
+        state = simulate(libhandle, simple_circ, algorithm, cfg)
+        assert state.is_valid()
+        copy_state = state.copy()
+        assert copy_state.is_valid()
+        assert np.isclose(copy_state.vdot(state), 1.0, atol=cfg._atol)
+
+        # Bounded chi
+        cfg = Config(chi=8)
+        state = simulate(libhandle, simple_circ, algorithm, cfg)
+        assert state.is_valid()
+        copy_state = state.copy()
+        assert copy_state.is_valid()
+        assert np.isclose(copy_state.vdot(state), 1.0, atol=cfg._atol)
+
+        # Bounded truncation_fidelity
+        cfg = Config(truncation_fidelity=0.9999)
+        state = simulate(libhandle, simple_circ, algorithm, cfg)
+        assert state.is_valid()
+        copy_state = state.copy()
+        assert copy_state.is_valid()
+        assert np.isclose(copy_state.vdot(state), 1.0, atol=cfg._atol)
+
+
 def test_canonicalise_mps() -> None:
     cp.random.seed(1)
     circ = Circuit(5)


### PR DESCRIPTION
# Description

Users can only choose whether to use a bounded `chi` or a bounded `truncation_fidelity` when using simulation methods from `structured_state`. If both are bounded by the user, an error is raised. 

However, internally, both of these are set to some default value when the user does not bound them. This caused the "user error" to be raised when copying a state with `truncation_fidelity` bounded by the user, because the initialiser of the copy would interpret that the default value of `chi` was also specified by the user. The fix I went for is to check whether the value of `chi` is the default one, before raising the error (something that was already done for `truncation_fidelity`.

# Checklist

- [x] I have run the tests on a machine with GPUs.
- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
