### PR TITLE
Bugfix release version cannot run KaHyPar

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+0.6.1 (April 2024)
+------------------
+
+* When using ``simulate`` with ``TTNxGate`` algorithm, the initial partition is obtained using NetworkX instead of KaHyPar by default. This makes setup easier and means that ``TTNxGate`` can now be used when installing from PyPI. KaHyPar can still be used if ``use_kahypar`` from ``Config`` is set to True.
+
 0.6.0 (April 2024)
 ------------------
 

--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -82,6 +82,7 @@ class Config:
         float_precision: Type[Any] = np.float64,
         value_of_zero: float = 1e-16,
         leaf_size: int = 8,
+        use_kahypar: bool = False,
         k: int = 4,
         optim_delta: float = 1e-5,
         loglevel: int = logging.WARNING,
@@ -113,6 +114,9 @@ class Config:
                 ``np.float64`` precision (default) and ``1e-7`` for ``np.float32``.
             leaf_size: For ``TTN`` simulation only. Sets the maximum number of
                 qubits in a leaf node when using ``TTN``. Default is 8.
+            use_kahypar: Use KaHyPar for graph partitioning (used in ``TTN``) if this
+                is True. Otherwise, use NetworkX (worse, but easy to setup). Defaults
+                to False.
             k: For ``MPSxMPO`` simulation only. Sets the maximum number of layers
                 the MPO is allowed to have before being contracted. Increasing this
                 might increase fidelity, but it will also increase resource requirements
@@ -177,6 +181,7 @@ class Config:
             raise ValueError("Maximum allowed leaf_size is 65.")
 
         self.leaf_size = leaf_size
+        self.use_kahypar = use_kahypar
         self.k = k
         self.optim_delta = 1e-5
         self.loglevel = loglevel

--- a/pytket/extensions/cutensornet/structured_state/simulation.py
+++ b/pytket/extensions/cutensornet/structured_state/simulation.py
@@ -100,7 +100,9 @@ def simulate(
         sorted_gates = _get_sorted_gates(circuit, algorithm)
 
     elif algorithm == SimulationAlgorithm.TTNxGate:
-        qubit_partition = _get_qubit_partition(circuit, config.leaf_size)
+        qubit_partition = _get_qubit_partition(
+            circuit, config.leaf_size, config.use_kahypar
+        )
         state = TTNxGate(  # type: ignore
             libhandle,
             qubit_partition,
@@ -163,7 +165,7 @@ def prepare_circuit_mps(circuit: Circuit) -> tuple[Circuit, dict[Qubit, Qubit]]:
 
 
 def _get_qubit_partition(
-    circuit: Circuit, max_q_per_leaf: int
+    circuit: Circuit, max_q_per_leaf: int, use_kahypar: bool
 ) -> dict[int, list[Qubit]]:
     """Returns a qubit partition for a TTN.
 
@@ -174,6 +176,8 @@ def _get_qubit_partition(
     Args:
         circuit: The circuit to be simulated.
         max_q_per_leaf: The maximum allowed number of qubits per node leaf
+        use_kahypar: Use KaHyPar for graph partitioning if this is True.
+            Otherwise, use NetworkX (worse, but easy to setup).
 
     Returns:
         A dictionary describing the partition in the format expected by TTN.
@@ -214,9 +218,14 @@ def _get_qubit_partition(
         old_partition = partition.copy()
         for key, group in old_partition.items():
             # Apply the balanced bisection on this group
-            (groupA, groupB) = _apply_kahypar_bisection(
-                connectivity_graph.subgraph(group),
-            )
+            if use_kahypar:  # Using KaHyPar
+                (groupA, groupB) = _apply_kahypar_bisection(
+                    connectivity_graph.subgraph(group),
+                )
+            else:  # Using NetworkX
+                (groupA, groupB) = nx.community.kernighan_lin_bisection(
+                    connectivity_graph.subgraph(group),
+                )
             # Groups A and B are on the same subtree (key separated by +1)
             partition[2 * key] = groupA
             partition[2 * key + 1] = groupB

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.26"],
+    install_requires=["pytket ~= 1.26", "networkx >= 2.8"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.26", "networkx >= 2.8"],
+    install_requires=["pytket ~= 1.26", "networkx ~= 3.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.10",

--- a/tests/test_structured_state.py
+++ b/tests/test_structured_state.py
@@ -63,7 +63,6 @@ def test_copy(algorithm: SimulationAlgorithm) -> None:
     simple_circ = Circuit(2).H(0).H(1).CX(0, 1)
 
     with CuTensorNetHandle() as libhandle:
-
         # Default config
         cfg = Config()
         state = simulate(libhandle, simple_circ, algorithm, cfg)

--- a/tests/test_structured_state.py
+++ b/tests/test_structured_state.py
@@ -530,7 +530,7 @@ def test_circ_approx_explicit_ttn(circuit: Circuit) -> None:
         # Check for TTNxGate
         cfg = Config(truncation_fidelity=0.99, leaf_size=3, float_precision=np.float32)
         ttn_gate = simulate(libhandle, circuit, SimulationAlgorithm.TTNxGate, cfg)
-        assert np.isclose(ttn_gate.get_fidelity(), 0.769, atol=1e-3)
+        assert np.isclose(ttn_gate.get_fidelity(), 0.751, atol=1e-3)
         assert ttn_gate.is_valid()
         assert np.isclose(ttn_gate.vdot(ttn_gate), 1.0, atol=cfg._atol)
 
@@ -538,7 +538,7 @@ def test_circ_approx_explicit_ttn(circuit: Circuit) -> None:
         # Check for TTNxGate
         cfg = Config(chi=120, leaf_size=3, float_precision=np.float32)
         ttn_gate = simulate(libhandle, circuit, SimulationAlgorithm.TTNxGate, cfg)
-        assert np.isclose(ttn_gate.get_fidelity(), 0.857, atol=1e-3)
+        assert np.isclose(ttn_gate.get_fidelity(), 0.854, atol=1e-3)
         assert ttn_gate.is_valid()
         assert np.isclose(ttn_gate.vdot(ttn_gate), 1.0, atol=cfg._atol)
 


### PR DESCRIPTION
# Description

Now NetworkX is used as the default option for partition, and KaHyPar is left for advanced users. In particular, only those who install from repository will be able to use KaHyPar (if they choose to do so with the appropriate `Config` option). This is something I will continue to play with, this is meant just as a hotfix.

# Related issues

Fixes #97 

# Checklist

- [x] I have tested that the code runs on a device with GPUs.
- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
