### PR TITLE
Feature/relabel qubits

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* New feature: ``apply_qubit_relabelling`` both for ``MPS`` and ``TTN`` to change the name of their qubits. This is now used within ``simulate`` to take into account the action of implicit SWAPs in pytket circuits (no additional SWAP gates are applied).
+
 0.6.1 (April 2024)
 ------------------
 

--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -241,6 +241,24 @@ class StructuredState(ABC):
         raise NotImplementedError(f"Method not implemented in {type(self).__name__}.")
 
     @abstractmethod
+    def apply_qubit_relabelling(self, qubit_map: dict[Qubit, Qubit]) -> StructuredState:
+        """Relabels each qubit ``q`` as ``qubit_map[q]``.
+
+        This does not apply any SWAP gate, nor it changes the internal structure of the
+        state. It simply changes the label of the physical bonds of the tensor network.
+
+        Args:
+            qubit_map: Dictionary mapping each qubit to its new label.
+
+        Returns:
+            ``self``, to allow for method chaining.
+
+        Raises:
+            ValueError: If any of the keys in ``qubit_map`` are not qubits in the state.
+        """
+        raise NotImplementedError(f"Method not implemented in {type(self).__name__}.")
+
+    @abstractmethod
     def vdot(self, other: StructuredState) -> complex:
         """Obtain the inner product of the two states: ``<self|other>``.
 

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -217,6 +217,33 @@ class MPS(StructuredState):
         self.tensors[0] *= scalar
         return self
 
+    def apply_qubit_relabelling(self, qubit_map: dict[Qubit, Qubit]) -> MPS:
+        """Relabels each qubit ``q`` as ``qubit_map[q]``.
+
+        This does not apply any SWAP gate, nor it changes the internal structure of the
+        state. It simply changes the label of the physical bonds of the tensor network.
+
+        Args:
+            qubit_map: Dictionary mapping each qubit to its new label.
+
+        Returns:
+            ``self``, to allow for method chaining.
+
+        Raises:
+            ValueError: If any of the keys in ``qubit_map`` are not qubits in the state.
+        """
+        new_qubit_position = dict()
+        for q_orig, q_new in qubit_map.items():
+            # Check the qubit is in the state
+            if q_orig not in self.qubit_position:
+                raise ValueError(f"Qubit {q_orig} is not in the state.")
+            # Apply the relabelling for this qubit
+            new_qubit_position[q_new] = self.qubit_position[q_orig]
+
+        self.qubit_position = new_qubit_position
+        self._logger.debug(f"Relabelled qubits... {qubit_map}")
+        return self
+
     def canonicalise(self, l_pos: int, r_pos: int) -> None:
         """Canonicalises the MPS object.
 

--- a/pytket/extensions/cutensornet/structured_state/simulation.py
+++ b/pytket/extensions/cutensornet/structured_state/simulation.py
@@ -122,6 +122,9 @@ def simulate(
     # Apply the circuit's phase to the state
     state.apply_scalar(np.exp(1j * np.pi * circuit.phase))
 
+    # Relabel qubits according to the implicit swaps (if any)
+    state.apply_qubit_relabelling(circuit.implicit_qubit_permutation())
+
     logger.info("Simulation completed.")
     logger.info(f"Final StructuredState size={state.get_byte_size() / 2**20} MiB")
     logger.info(f"Final StructuredState fidelity={state.fidelity}")
@@ -138,6 +141,7 @@ def prepare_circuit_mps(circuit: Circuit) -> tuple[Circuit, dict[Qubit, Qubit]]:
         The qubits in the output circuit will be renamed. Implicit SWAPs may be added
         to the circuit, meaning that the logical qubit held at the ``node[i]`` qubit
         at the beginning of the circuit may differ from the one it holds at the end.
+        Consider applying ``apply_qubit_relabelling`` on the MPS after simulation.
 
     Args:
         circuit: The circuit to be simulated.

--- a/pytket/extensions/cutensornet/structured_state/ttn.py
+++ b/pytket/extensions/cutensornet/structured_state/ttn.py
@@ -289,6 +289,33 @@ class TTN(StructuredState):
         self.nodes[()].tensor *= scalar
         return self
 
+    def apply_qubit_relabelling(self, qubit_map: dict[Qubit, Qubit]) -> TTN:
+        """Relabels each qubit ``q`` as ``qubit_map[q]``.
+
+        This does not apply any SWAP gate, nor it changes the internal structure of the
+        state. It simply changes the label of the physical bonds of the tensor network.
+
+        Args:
+            qubit_map: Dictionary mapping each qubit to its new label.
+
+        Returns:
+            ``self``, to allow for method chaining.
+
+        Raises:
+            ValueError: If any of the keys in ``qubit_map`` are not qubits in the state.
+        """
+        new_qubit_position = dict()
+        for q_orig, q_new in qubit_map.items():
+            # Check the qubit is in the state
+            if q_orig not in self.qubit_position:
+                raise ValueError(f"Qubit {q_orig} is not in the state.")
+            # Apply the relabelling for this qubit
+            new_qubit_position[q_new] = self.qubit_position[q_orig]
+
+        self.qubit_position = new_qubit_position
+        self._logger.debug(f"Relabelled qubits... {qubit_map}")
+        return self
+
     def canonicalise(
         self, center: Union[RootPath, Qubit], unsafe: bool = False
     ) -> Tensor:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 import pytest
 import numpy as np
 from scipy.stats import unitary_group  # type: ignore
-from pytket.circuit import Circuit, OpType, Unitary2qBox
-from pytket.passes import DecomposeBoxes
+from pytket.circuit import Circuit, OpType, Unitary2qBox, ToffoliBox, Qubit
+from pytket.passes import DecomposeBoxes, CnXPairwiseDecomposition
+from pytket.transform import Transform
 
 
 def random_line_circuit(n_qubits: int, layers: int) -> Circuit:
@@ -253,3 +254,28 @@ def q8_qvol() -> Circuit:
 def q15_qvol() -> Circuit:
     np.random.seed(1)
     return quantum_volume_circuit(n_qubits=15)
+
+
+@pytest.fixture
+def q3_toffoli_box_with_implicit_swaps() -> Circuit:
+    # Using specific permutation here
+    perm = {
+        (False, False): (True, True),
+        (False, True): (False, False),
+        (True, False): (True, False),
+        (True, True): (False, True),
+    }
+
+    # Create a circuit with more qubits and multiple applications of the permutation
+    # above
+    circ = Circuit(3)
+
+    # Create the circuit
+    circ.add_toffolibox(ToffoliBox(perm), [Qubit(0), Qubit(1)])  # type: ignore
+    circ.add_toffolibox(ToffoliBox(perm), [Qubit(1), Qubit(2)])  # type: ignore
+
+    DecomposeBoxes().apply(circ)
+    CnXPairwiseDecomposition().apply(circ)
+    Transform.OptimiseCliffords().apply(circ)
+
+    return circ

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,4 +278,8 @@ def q3_toffoli_box_with_implicit_swaps() -> Circuit:
     CnXPairwiseDecomposition().apply(circ)
     Transform.OptimiseCliffords().apply(circ)
 
+    # Check that, indeed, there are implicit swaps
+    implicit_perm = circ.implicit_qubit_permutation()
+    assert any(qin != qout for qin, qout in implicit_perm.items())
+
     return circ

--- a/tests/test_structured_state.py
+++ b/tests/test_structured_state.py
@@ -262,6 +262,7 @@ def test_canonicalise_ttn(center: Union[RootPath, Qubit]) -> None:
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q3_toffoli_box_with_implicit_swaps"),  # type: ignore
         pytest.lazy_fixture("q4_with_creates"),  # type: ignore
         pytest.lazy_fixture("q5_h0s1rz2ry3tk4tk13"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
@@ -324,6 +325,7 @@ def test_exact_circ_sim(circuit: Circuit, algorithm: SimulationAlgorithm) -> Non
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q3_toffoli_box_with_implicit_swaps"),  # type: ignore
         pytest.lazy_fixture("q4_with_creates"),  # type: ignore
         pytest.lazy_fixture("q5_h0s1rz2ry3tk4tk13"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
@@ -372,6 +374,7 @@ def test_approx_circ_sim_gate_fid(
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_v0cx02"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q3_toffoli_box_with_implicit_swaps"),  # type: ignore
         pytest.lazy_fixture("q4_with_creates"),  # type: ignore
         pytest.lazy_fixture("q5_h0s1rz2ry3tk4tk13"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
@@ -586,6 +589,7 @@ def test_postselect_2q_circ(circuit: Circuit, postselect_dict: dict) -> None:
     "circuit",
     [
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q3_toffoli_box_with_implicit_swaps"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
     ],
 )
@@ -607,7 +611,11 @@ def test_postselect_circ(circuit: Circuit, postselect_dict: dict) -> None:
 
     with CuTensorNetHandle() as libhandle:
         cfg = Config()
+
+        circuit, qubit_map = prepare_circuit_mps(circuit)
         mps = simulate(libhandle, circuit, SimulationAlgorithm.MPSxGate, cfg)
+        mps.apply_qubit_relabelling(qubit_map)
+
         prob = mps.postselect(postselect_dict)
         assert np.isclose(prob, sv_prob, atol=cfg._atol)
         assert np.allclose(mps.get_statevector(), sv, atol=cfg._atol)
@@ -626,6 +634,7 @@ def test_postselect_circ(circuit: Circuit, postselect_dict: dict) -> None:
         pytest.lazy_fixture("q2_lcu2"),  # type: ignore
         pytest.lazy_fixture("q2_lcu3"),  # type: ignore
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q3_toffoli_box_with_implicit_swaps"),  # type: ignore
         pytest.lazy_fixture("q4_with_creates"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
     ],
@@ -654,7 +663,9 @@ def test_expectation_value(circuit: Circuit, observable: QubitPauliString) -> No
     # Simulate the circuit and obtain the expectation value
     with CuTensorNetHandle() as libhandle:
         cfg = Config()
+        circuit, qubit_map = prepare_circuit_mps(circuit)
         mps = simulate(libhandle, circuit, SimulationAlgorithm.MPSxGate, cfg)
+        mps.apply_qubit_relabelling(qubit_map)
         assert np.isclose(
             mps.expectation_value(observable), expectation_value, atol=cfg._atol
         )
@@ -701,6 +712,7 @@ def test_sample_circ_2q(circuit: Circuit) -> None:
     "circuit",
     [
         pytest.lazy_fixture("q3_cx01cz12x1rx0"),  # type: ignore
+        pytest.lazy_fixture("q3_toffoli_box_with_implicit_swaps"),  # type: ignore
         pytest.lazy_fixture("q5_line_circ_30_layers"),  # type: ignore
     ],
 )
@@ -711,7 +723,9 @@ def test_measure_circ(circuit: Circuit) -> None:
     qB = circuit.qubits[-3]  # Third list significant qubit
 
     with CuTensorNetHandle() as libhandle:
+        circuit, qubit_map = prepare_circuit_mps(circuit)
         mps = simulate(libhandle, circuit, SimulationAlgorithm.MPSxGate, Config())
+        mps.apply_qubit_relabelling(qubit_map)
 
         # Compute the probabilities of each outcome
         p = {(0, 0): 0.0, (0, 1): 0.0, (1, 0): 0.0, (1, 1): 0.0}


### PR DESCRIPTION
# Description

New feature: ``apply_qubit_relabelling`` both for ``MPS`` and ``TTN`` to change the name of their qubits. This is now used within ``simulate`` to take into account the action of implicit SWAPs in pytket circuits (no additional SWAP gates are applied).

Note: There's no rush to get this released/merged.

# Checklist

- [x] I have run the tests on a device with GPUs.
- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
