### PR TITLE
Refactor: apply_matrix to any StructuredState and destroy CuTensorNetHandle

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+* New feature: ``apply_unitary`` both for ``MPS`` and ``TTN`` to apply an arbitrary unitary matrix, rather than a ``pytket.Command``.
 * New feature: ``apply_qubit_relabelling`` both for ``MPS`` and ``TTN`` to change the name of their qubits. This is now used within ``simulate`` to take into account the action of implicit SWAPs in pytket circuits (no additional SWAP gates are applied).
 
 0.6.1 (April 2024)

--- a/docs/modules/structured_state.rst
+++ b/docs/modules/structured_state.rst
@@ -18,13 +18,14 @@ Simulation
 
 .. autoclass:: pytket.extensions.cutensornet.structured_state.CuTensorNetHandle
 
+    .. automethod:: destroy
+
 
 Classes
 ~~~~~~~
 
 .. autoclass:: pytket.extensions.cutensornet.structured_state.StructuredState()
 
-    .. automethod:: __init__
     .. automethod:: is_valid
     .. automethod:: apply_gate
     .. automethod:: apply_unitary

--- a/docs/modules/structured_state.rst
+++ b/docs/modules/structured_state.rst
@@ -27,6 +27,7 @@ Classes
     .. automethod:: __init__
     .. automethod:: is_valid
     .. automethod:: apply_gate
+    .. automethod:: apply_unitary
     .. automethod:: apply_scalar
     .. automethod:: vdot
     .. automethod:: sample

--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -224,7 +224,35 @@ class StructuredState(ABC):
 
         Raises:
             RuntimeError: If the ``CuTensorNetHandle`` is out of scope.
-            RuntimeError: If gate is not supported.
+            ValueError: If the command introduced is not a unitary gate.
+            ValueError: If gate acts on more than 2 qubits.
+        """
+        raise NotImplementedError(f"Method not implemented in {type(self).__name__}.")
+
+    @abstractmethod
+    def apply_unitary(
+        self, unitary: cp.ndarray, qubits: list[Qubit]
+    ) -> StructuredState:
+        """Applies the unitary to the specified qubits of the StructuredState.
+
+        Note:
+            It is assumed that the matrix provided by the user is unitary. If this is
+            not the case, the program will still run, but its behaviour is undefined.
+
+        Args:
+            unitary: The matrix to be applied as a CuPy ndarray. It should either be
+                a 2x2 matrix if acting on one qubit or a 4x4 matrix if acting on two.
+            qubits: The qubits the unitary acts on. Only one qubit and two qubit
+                unitaries are supported.
+
+        Returns:
+            ``self``, to allow for method chaining.
+
+        Raises:
+            RuntimeError: If the ``CuTensorNetHandle`` is out of scope.
+            ValueError: If the number of qubits provided is not one or two.
+            ValueError: If the size of the matrix does not match with the number of
+                qubits provided.
         """
         raise NotImplementedError(f"Method not implemented in {type(self).__name__}.")
 

--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -64,12 +64,20 @@ class CuTensorNetHandle:
 
         self.handle = cutn.create()
 
+    def destroy(self) -> None:
+        """Destroys the memory handle, releasing memory.
+
+        Only call this method if you are initialising a ``CuTensorNetHandle`` outside
+        a ``with CuTensorNetHandle() as libhandle`` statement.
+        """
+        cutn.destroy(self.handle)
+        self._is_destroyed = True
+
     def __enter__(self) -> CuTensorNetHandle:
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, exc_tb: Any) -> None:
-        cutn.destroy(self.handle)
-        self._is_destroyed = True
+        self.destroy()
 
 
 class Config:

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -174,6 +174,12 @@ class MPS(StructuredState):
         unitary = cp.asarray(unitary, dtype=self._cfg._complex_t)
 
         self._logger.debug(f"Applying gate {gate}.")
+        if len(gate.qubits) not in [1, 2]:
+            raise ValueError(
+                "Gates must act on only 1 or 2 qubits! "
+                + f"This is not satisfied by {gate}."
+            )
+
         self.apply_unitary(unitary, gate.qubits)
 
         return self

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -160,9 +160,48 @@ class MPS(StructuredState):
 
         Raises:
             RuntimeError: If the ``CuTensorNetHandle`` is out of scope.
-            RuntimeError: If gate acts on more than 2 qubits or acts on non-adjacent
+            ValueError: If the command introduced is not a unitary gate.
+            ValueError: If gate acts on more than 2 qubits or acts on non-adjacent
                 qubits.
-            RuntimeError: If physical bond dimension where gate is applied is not 2.
+        """
+        try:
+            unitary = gate.op.get_unitary()
+        except:
+            raise ValueError("The command introduced is not unitary.")
+
+        # Load the gate's unitary to the GPU memory
+        unitary = unitary.astype(dtype=self._cfg._complex_t, copy=False)
+        unitary = cp.asarray(unitary, dtype=self._cfg._complex_t)
+
+        self._logger.debug(f"Applying gate {gate}.")
+        self.apply_unitary(unitary, gate.qubits)
+
+        return self
+
+    def apply_unitary(
+        self, unitary: cp.ndarray, qubits: list[Qubit]
+    ) -> StructuredState:
+        """Applies the unitary to the specified qubits of the StructuredState.
+
+        Note:
+            It is assumed that the matrix provided by the user is unitary. If this is
+            not the case, the program will still run, but its behaviour is undefined.
+
+        Args:
+            unitary: The matrix to be applied as a CuPy ndarray. It should either be
+                a 2x2 matrix if acting on one qubit or a 4x4 matrix if acting on two.
+            qubits: The qubits the unitary acts on. Only one qubit and two qubit
+                unitaries are supported.
+
+        Returns:
+            ``self``, to allow for method chaining.
+
+        Raises:
+            RuntimeError: If the ``CuTensorNetHandle`` is out of scope.
+            ValueError: If the number of qubits provided is not one or two.
+            ValueError: If the size of the matrix does not match with the number of
+                qubits provided.
+            ValueError: If qubits are non-adjacent.
         """
         if self._lib._is_destroyed:
             raise RuntimeError(
@@ -170,38 +209,37 @@ class MPS(StructuredState):
                 "See the documentation of update_libhandle and CuTensorNetHandle.",
             )
 
-        positions = [self.qubit_position[q] for q in gate.qubits]
-        if any(self.get_physical_dimension(pos) != 2 for pos in positions):
-            raise RuntimeError(
-                "Gates can only be applied to tensors with physical"
-                + " bond dimension of 2."
-            )
-        self._logger.debug(f"Applying gate {gate}")
+        self._logger.debug(f"Applying unitary {unitary} on {qubits}.")
 
-        if len(positions) == 1:
-            self._apply_1q_gate(positions[0], gate.op)
+        if len(qubits) == 1:
+            if unitary.shape != (2, 2):
+                raise ValueError(
+                    "The unitary introduced acts on one qubit but it is not 2x2."
+                )
+
+            self._apply_1q_unitary(unitary, qubits[0])
             # NOTE: if the tensor was in canonical form, it remains being so,
             #   since it is guaranteed that the gate is unitary.
 
-        elif len(positions) == 2:
+        elif len(qubits) == 2:
+            if unitary.shape != (4, 4):
+                raise ValueError(
+                    "The unitary introduced acts on two qubits but it is not 4x4."
+                )
+
+            positions = [self.qubit_position[q] for q in qubits]
             dist = positions[1] - positions[0]
             # We explicitly allow both dist==1 or dist==-1 so that non-symmetric
             # gates such as CX can use the same Op for the two ways it can be in.
             if dist not in [1, -1]:
-                raise RuntimeError(
-                    "Gates must be applied to adjacent qubits! "
-                    + f"This is not satisfied by {gate}."
-                )
-            self._apply_2q_gate((positions[0], positions[1]), gate.op)
+                raise ValueError("Gates must be applied to adjacent qubits!")
+            self._apply_2q_unitary(unitary, qubits[0], qubits[1])
             # The tensors will in general no longer be in canonical form.
             self.canonical_form[positions[0]] = None
             self.canonical_form[positions[1]] = None
 
         else:
-            raise RuntimeError(
-                "Gates must act on only 1 or 2 qubits! "
-                + f"This is not satisfied by {gate}."
-            )
+            raise ValueError("Gates must act on only 1 or 2 qubits!")
 
         return self
 
@@ -919,13 +957,13 @@ class MPS(StructuredState):
         """
         return len(self.tensors)
 
-    def _apply_1q_gate(self, position: int, gate: Op) -> MPS:
+    def _apply_1q_unitary(self, unitary: cp.ndarray, qubit: Qubit) -> MPS:
         raise NotImplementedError(
             "MPS is a base class with no contraction algorithm implemented."
             + " You must use a subclass of MPS, such as MPSxGate or MPSxMPO."
         )
 
-    def _apply_2q_gate(self, positions: tuple[int, int], gate: Op) -> MPS:
+    def _apply_2q_unitary(self, unitary: cp.ndarray, q0: Qubit, q1: Qubit) -> MPS:
         raise NotImplementedError(
             "MPS is a base class with no contraction algorithm implemented."
             + " You must use a subclass of MPS, such as MPSxGate or MPSxMPO."

--- a/pytket/extensions/cutensornet/structured_state/ttn.py
+++ b/pytket/extensions/cutensornet/structured_state/ttn.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     warnings.warn("local settings failed to import cutensornet", ImportWarning)
 
-from pytket.circuit import Command, Op, Qubit
+from pytket.circuit import Command, Qubit
 from pytket.pauli import QubitPauliString
 
 from pytket.extensions.cutensornet.general import set_logger
@@ -252,7 +252,46 @@ class TTN(StructuredState):
 
         Raises:
             RuntimeError: If the ``CuTensorNetHandle`` is out of scope.
-            RuntimeError: If gate acts on more than 2 qubits.
+            ValueError: If the command introduced is not a unitary gate.
+            ValueError: If gate acts on more than 2 qubits.
+        """
+        try:
+            unitary = gate.op.get_unitary()
+        except:
+            raise ValueError("The command introduced is not unitary.")
+
+        # Load the gate's unitary to the GPU memory
+        unitary = unitary.astype(dtype=self._cfg._complex_t, copy=False)
+        unitary = cp.asarray(unitary, dtype=self._cfg._complex_t)
+
+        self._logger.debug(f"Applying gate {gate}.")
+        self.apply_unitary(unitary, gate.qubits)
+
+        return self
+
+    def apply_unitary(
+        self, unitary: cp.ndarray, qubits: list[Qubit]
+    ) -> StructuredState:
+        """Applies the unitary to the specified qubits of the StructuredState.
+
+        Note:
+            It is assumed that the matrix provided by the user is unitary. If this is
+            not the case, the program will still run, but its behaviour is undefined.
+
+        Args:
+            unitary: The matrix to be applied as a CuPy ndarray. It should either be
+                a 2x2 matrix if acting on one qubit or a 4x4 matrix if acting on two.
+            qubits: The qubits the unitary acts on. Only one qubit and two qubit
+                unitaries are supported.
+
+        Returns:
+            ``self``, to allow for method chaining.
+
+        Raises:
+            RuntimeError: If the ``CuTensorNetHandle`` is out of scope.
+            ValueError: If the number of qubits provided is not one or two.
+            ValueError: If the size of the matrix does not match with the number of
+                qubits provided.
         """
         if self._lib._is_destroyed:
             raise RuntimeError(
@@ -260,20 +299,24 @@ class TTN(StructuredState):
                 "See the documentation of update_libhandle and CuTensorNetHandle.",
             )
 
-        self._logger.debug(f"Applying gate {gate}")
+        self._logger.debug(f"Applying unitary {unitary} on {qubits}.")
 
-        if len(gate.qubits) == 1:
-            self._apply_1q_gate(gate.qubits[0], gate.op)
+        if len(qubits) == 1:
+            if unitary.shape != (2, 2):
+                raise ValueError(
+                    "The unitary introduced acts on one qubit but it is not 2x2."
+                )
+            self._apply_1q_unitary(unitary, qubits[0])
 
-        elif len(gate.qubits) == 2:
-            self._apply_2q_gate(gate.qubits[0], gate.qubits[1], gate.op)
+        elif len(qubits) == 2:
+            if unitary.shape != (4, 4):
+                raise ValueError(
+                    "The unitary introduced acts on two qubits but it is not 4x4."
+                )
+            self._apply_2q_unitary(unitary, qubits[0], qubits[1])
 
         else:
-            # NOTE: This could be supported if gate acts on same group of qubits
-            raise RuntimeError(
-                "Gates must act on only 1 or 2 qubits! "
-                + f"This is not satisfied by {gate}."
-            )
+            raise ValueError("Gates must act on only 1 or 2 qubits!")
 
         return self
 
@@ -855,13 +898,13 @@ class TTN(StructuredState):
         )
         return new_ttn
 
-    def _apply_1q_gate(self, qubit: Qubit, gate: Op) -> TTN:
+    def _apply_1q_unitary(self, unitary: cp.ndarray, qubit: Qubit) -> TTN:
         raise NotImplementedError(
             "TTN is a base class with no contraction algorithm implemented."
             + " You must use a subclass of TTN, such as TTNxGate."
         )
 
-    def _apply_2q_gate(self, q0: Qubit, q1: Qubit, gate: Op) -> TTN:
+    def _apply_2q_unitary(self, unitary: cp.ndarray, q0: Qubit, q1: Qubit) -> TTN:
         raise NotImplementedError(
             "TTN is a base class with no contraction algorithm implemented."
             + " You must use a subclass of TTN, such as TTNxGate."


### PR DESCRIPTION
# Description

- Refactors `apply_gate` and related functions `_apply_1q_gate` and `_apply_2q_gate` both from `MPS` and `TTN` algorithms so that it exposes a method `apply_unitary` that allows users to make use of these algorithms without having a list of `pytket.Command`s.
- Refactors `CuTensorNetHandle` so that there is an explicit `destroy` method, for users that do not wish to (or cannot) use the `with`-statement syntactic sugar.

# Related issues

This is necessary for integration with PECOS.

# Checklist

- [x] I have run the tests on a device with GPUs.
- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
