### PR TITLE
Feature: MPS add_qubit and non-destructive measurements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+* New feature: ``add_qubit`` to add fresh qubits at specified positions in an ``MPS``.
+* New feature: added an option to ``measure`` to toggle destructive measurement on/off. Currently only supported for ``MPS``.
 * New feature: ``apply_unitary`` both for ``MPS`` and ``TTN`` to apply an arbitrary unitary matrix, rather than a ``pytket.Command``.
 * New feature: ``apply_qubit_relabelling`` both for ``MPS`` and ``TTN`` to change the name of their qubits. This is now used within ``simulate`` to take into account the action of implicit SWAPs in pytket circuits (no additional SWAP gates are applied).
 

--- a/docs/modules/structured_state.rst
+++ b/docs/modules/structured_state.rst
@@ -51,10 +51,12 @@ Classes
 .. autoclass:: pytket.extensions.cutensornet.structured_state.MPSxGate()
 
     .. automethod:: __init__
+    .. automethod:: add_qubit
 
 .. autoclass:: pytket.extensions.cutensornet.structured_state.MPSxMPO()
 
     .. automethod:: __init__
+    .. automethod:: add_qubit
 
 
 Miscellaneous

--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -330,7 +330,7 @@ class StructuredState(ABC):
         raise NotImplementedError(f"Method not implemented in {type(self).__name__}.")
 
     @abstractmethod
-    def measure(self, qubits: set[Qubit], destructive: bool=True) -> dict[Qubit, int]:
+    def measure(self, qubits: set[Qubit], destructive: bool = True) -> dict[Qubit, int]:
         """Applies a Z measurement on each of the ``qubits``.
 
         Notes:

--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -330,17 +330,18 @@ class StructuredState(ABC):
         raise NotImplementedError(f"Method not implemented in {type(self).__name__}.")
 
     @abstractmethod
-    def measure(self, qubits: set[Qubit]) -> dict[Qubit, int]:
-        """Applies a Z measurement on ``qubits``, updates the state and returns outcome.
+    def measure(self, qubits: set[Qubit], destructive: bool=True) -> dict[Qubit, int]:
+        """Applies a Z measurement on each of the ``qubits``.
 
         Notes:
-            After applying this function, ``self`` will contain the projected
-            state over the non-measured qubits.
-
-            The resulting state has been normalised.
+            After applying this function, ``self`` will contain the normalised
+            projected state.
 
         Args:
             qubits: The subset of qubits to be measured.
+            destructive: If ``True``, the resulting state will not contain the
+                measured qubits. If ``False``, these qubits will appear on the
+                state corresponding to the measurement outcome. Defaults to ``True``.
 
         Returns:
             A dictionary mapping the given ``qubits`` to their measurement outcome,

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -288,7 +288,7 @@ class MPS(StructuredState):
         self._logger.debug(f"Relabelled qubits... {qubit_map}")
         return self
 
-    def add_qubit(self, new_qubit: Qubit, position: int, state: int=0) -> MPS:
+    def add_qubit(self, new_qubit: Qubit, position: int, state: int = 0) -> MPS:
         """Adds a qubit on state |0> at the specified position.
 
         Args:
@@ -312,9 +312,7 @@ class MPS(StructuredState):
                 f"Qubit {new_qubit} cannot be added, it already is in the MPS."
             )
         if position < 0 or position > len(self):
-            raise ValueError(
-                f"Index {position} is not a valid position in the MPS."
-            )
+            raise ValueError(f"Index {position} is not a valid position in the MPS.")
         if state not in [0, 1]:
             raise ValueError(
                 f"Cannot initialise qubit to state {state}. Only 0 or 1 are supported."
@@ -588,7 +586,7 @@ class MPS(StructuredState):
         mps = self.copy()
         return mps.measure(mps.get_qubits())
 
-    def measure(self, qubits: set[Qubit], destructive: bool=True) -> dict[Qubit, int]:
+    def measure(self, qubits: set[Qubit], destructive: bool = True) -> dict[Qubit, int]:
         """Applies a Z measurement on each of the ``qubits``.
 
         Notes:

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -342,13 +342,13 @@ class MPS(StructuredState):
         orig_mps_len = len(self)  # Store it in variable, since this will change
         self.tensors.insert(position, new_tensor)
 
-        # Update the dictionary tracking canonical form
+        # Update the dictionary tracking the canonical form
         for pos in reversed(range(position, orig_mps_len)):
             self.canonical_form[pos + 1] = self.canonical_form[pos]
-        # Note: the canonical form of ``new_tensor`` is *both* left and right, so we
-        #   can leave `self.canonical_form[position]` to be whatever it was before.
+        # The canonical form of the new tensor is both LEFT and RIGHT, just choose one
+        self.canonical_form[position] = DirMPS.LEFT
 
-        # Finally, update the dictionary tracking qubit position
+        # Finally, update the dictionary tracking the qubit position
         for q, pos in self.qubit_position.items():
             if pos >= position:
                 self.qubit_position[q] += 1

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -289,13 +289,14 @@ class MPS(StructuredState):
         return self
 
     def add_qubit(self, new_qubit: Qubit, position: int, state: int = 0) -> MPS:
-        """Adds a qubit on state ``|0>`` at the specified position.
+        """Adds a qubit at the specified position.
 
         Args:
             new_qubit: The identifier of the qubit to be added to the state.
             position: The location the new qubit should be inserted at in the MPS.
                 Qubits on this and later indexed have their position shifted by 1.
             state: Choose either ``0`` or ``1`` for the new qubit's state.
+                Defaults to ``0``.
 
         Returns:
             ``self``, to allow for method chaining.

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -289,13 +289,13 @@ class MPS(StructuredState):
         return self
 
     def add_qubit(self, new_qubit: Qubit, position: int, state: int = 0) -> MPS:
-        """Adds a qubit on state |0> at the specified position.
+        """Adds a qubit on state ``|0>`` at the specified position.
 
         Args:
             new_qubit: The identifier of the qubit to be added to the state.
             position: The location the new qubit should be inserted at in the MPS.
                 Qubits on this and later indexed have their position shifted by 1.
-            state: Choose either ``0`` or ``1`` for the new qubit state.
+            state: Choose either ``0`` or ``1`` for the new qubit's state.
 
         Returns:
             ``self``, to allow for method chaining.
@@ -596,8 +596,8 @@ class MPS(StructuredState):
         Args:
             qubits: The subset of qubits to be measured.
             destructive: If ``True``, the resulting state will not contain the
-                measured qubits. If ``False``, these qubits will appear on the
-                state corresponding to the measurement outcome. Defaults to ``True``.
+                measured qubits. If ``False``, these qubits will remain in the
+                state. Defaults to ``True``.
 
         Returns:
             A dictionary mapping the given ``qubits`` to their measurement outcome,

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -346,7 +346,7 @@ class MPS(StructuredState):
         for pos in reversed(range(position, orig_mps_len)):
             self.canonical_form[pos + 1] = self.canonical_form[pos]
         # The canonical form of the new tensor is both LEFT and RIGHT, just choose one
-        self.canonical_form[position] = DirMPS.LEFT
+        self.canonical_form[position] = DirMPS.LEFT  # type: ignore
 
         # Finally, update the dictionary tracking the qubit position
         for q, pos in self.qubit_position.items():

--- a/pytket/extensions/cutensornet/structured_state/ttn.py
+++ b/pytket/extensions/cutensornet/structured_state/ttn.py
@@ -650,7 +650,7 @@ class TTN(StructuredState):
         """
         raise NotImplementedError(f"Method not implemented in {type(self).__name__}.")
 
-    def measure(self, qubits: set[Qubit], destructive: bool=True) -> dict[Qubit, int]:
+    def measure(self, qubits: set[Qubit], destructive: bool = True) -> dict[Qubit, int]:
         """Applies a Z measurement on each of the ``qubits``.
 
         Notes:

--- a/pytket/extensions/cutensornet/structured_state/ttn.py
+++ b/pytket/extensions/cutensornet/structured_state/ttn.py
@@ -650,17 +650,18 @@ class TTN(StructuredState):
         """
         raise NotImplementedError(f"Method not implemented in {type(self).__name__}.")
 
-    def measure(self, qubits: set[Qubit]) -> dict[Qubit, int]:
-        """Applies a Z measurement on ``qubits``, updates the state and returns outcome.
+    def measure(self, qubits: set[Qubit], destructive: bool=True) -> dict[Qubit, int]:
+        """Applies a Z measurement on each of the ``qubits``.
 
         Notes:
-            After applying this function, ``self`` will contain the projected
-            state over the non-measured qubits.
-
-            The resulting state has been normalised.
+            After applying this function, ``self`` will contain the normalised
+            projected state.
 
         Args:
             qubits: The subset of qubits to be measured.
+            destructive: If ``True``, the resulting state will not contain the
+                measured qubits. If ``False``, these qubits will appear on the
+                state corresponding to the measurement outcome. Defaults to ``True``.
 
         Returns:
             A dictionary mapping the given ``qubits`` to their measurement outcome,

--- a/tests/test_structured_state.py
+++ b/tests/test_structured_state.py
@@ -835,4 +835,3 @@ def test_mps_qubit_addition_and_measure() -> None:
         sv = np.zeros(2**4)
         sv[int("0100", 2)] = 1
         assert np.allclose(mps.get_statevector(), sv)
-

--- a/tests/test_structured_state.py
+++ b/tests/test_structured_state.py
@@ -663,9 +663,8 @@ def test_mps_qubit_addition() -> None:
         mps.apply_unitary(cx, [Qubit(6), Qubit(2)])  # |010101>
         mps.apply_unitary(cx, [Qubit(6), Qubit(3)])  # |010111>
         # Add another qubit at the end of the MPS
-        mps.add_qubit(new_qubit=Qubit(5), position=len(mps))  # |0101110>
+        mps.add_qubit(new_qubit=Qubit(5), position=len(mps), state=1)  # |0101111>
         # Apply some more gates acting on the new qubit
-        mps.apply_unitary(x, [Qubit(5)])  # |0101111>
         mps.apply_unitary(cx, [Qubit(4), Qubit(5)])  # |0101110>
 
         # The resulting state should be |0101110>

--- a/tests/test_structured_state.py
+++ b/tests/test_structured_state.py
@@ -621,66 +621,6 @@ def test_postselect_circ(circuit: Circuit, postselect_dict: dict) -> None:
         assert np.allclose(mps.get_statevector(), sv, atol=cfg._atol)
 
 
-def test_mps_qubit_addition() -> None:
-    with CuTensorNetHandle() as libhandle:
-        config = Config()
-        mps = MPSxGate(
-            libhandle,
-            qubits=[Qubit(0), Qubit(1), Qubit(2), Qubit(3)],
-            config=config,
-        )
-
-        x = cp.asarray(
-            [
-                [0, 1],
-                [1, 0],
-            ],
-            dtype=config._complex_t,
-        )
-        cx = cp.asarray(
-            [
-                [1, 0, 0, 0],
-                [0, 1, 0, 0],
-                [0, 0, 0, 1],
-                [0, 0, 1, 0],
-            ],
-            dtype=config._complex_t,
-        )
-
-        # Apply some gates
-        mps.apply_unitary(x, [Qubit(1)])  # |0100>
-        mps.apply_unitary(cx, [Qubit(1), Qubit(2)])  # |0110>
-        mps.apply_unitary(cx, [Qubit(2), Qubit(3)])  # |0111>
-        # Add a qubit at the end of the MPS
-        mps.add_qubit(new_qubit=Qubit(4), position=len(mps))  # |01110>
-        # Apply some more gates acting on the new qubit
-        mps.apply_unitary(cx, [Qubit(3), Qubit(4)])  # |01111>
-        mps.apply_unitary(cx, [Qubit(4), Qubit(3)])  # |01101>
-        # Add a qubit at position 3
-        mps.add_qubit(new_qubit=Qubit(6), position=3)  # |011001>
-        # Apply some more gates acting on the new qubit
-        mps.apply_unitary(x, [Qubit(6)])  # |011101>
-        mps.apply_unitary(cx, [Qubit(6), Qubit(2)])  # |010101>
-        mps.apply_unitary(cx, [Qubit(6), Qubit(3)])  # |010111>
-        # Add another qubit at the end of the MPS
-        mps.add_qubit(new_qubit=Qubit(5), position=len(mps), state=1)  # |0101111>
-        # Apply some more gates acting on the new qubit
-        mps.apply_unitary(cx, [Qubit(4), Qubit(5)])  # |0101110>
-
-        # The resulting state should be |0101110>
-        sv = np.zeros(2**7)
-        sv[int("0101110", 2)] = 1
-
-        # However, since mps.get_statevector will sort qubits in ILO, the bits would
-        # change position. Instead, we can relabel the qubits.
-        mps.apply_qubit_relabelling(
-            {q: Qubit(i) for q, i in mps.qubit_position.items()}
-        )
-
-        # Compare the state vectors
-        assert np.allclose(mps.get_statevector(), sv)
-
-
 @pytest.mark.parametrize(
     "circuit",
     [
@@ -804,3 +744,95 @@ def test_measure_circ(circuit: Circuit) -> None:
     # Check sample frequency consistent with theoretical probability
     for outcome, count in sample_dict.items():
         assert np.isclose(count / n_samples, p[outcome], atol=0.1)
+
+
+def test_mps_qubit_addition_and_measure() -> None:
+    with CuTensorNetHandle() as libhandle:
+        config = Config()
+        mps = MPSxGate(
+            libhandle,
+            qubits=[Qubit(0), Qubit(1), Qubit(2), Qubit(3)],
+            config=config,
+        )
+
+        x = cp.asarray(
+            [
+                [0, 1],
+                [1, 0],
+            ],
+            dtype=config._complex_t,
+        )
+        cx = cp.asarray(
+            [
+                [1, 0, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 0, 1],
+                [0, 0, 1, 0],
+            ],
+            dtype=config._complex_t,
+        )
+
+        # Apply some gates
+        mps.apply_unitary(x, [Qubit(1)])  # |0100>
+        mps.apply_unitary(cx, [Qubit(1), Qubit(2)])  # |0110>
+        mps.apply_unitary(cx, [Qubit(2), Qubit(3)])  # |0111>
+        # Add a qubit at the end of the MPS
+        mps.add_qubit(new_qubit=Qubit(4), position=len(mps))  # |01110>
+        # Apply some more gates acting on the new qubit
+        mps.apply_unitary(cx, [Qubit(3), Qubit(4)])  # |01111>
+        mps.apply_unitary(cx, [Qubit(4), Qubit(3)])  # |01101>
+        # Add a qubit at position 3
+        mps.add_qubit(new_qubit=Qubit(6), position=3)  # |011001>
+        # Apply some more gates acting on the new qubit
+        mps.apply_unitary(x, [Qubit(6)])  # |011101>
+        mps.apply_unitary(cx, [Qubit(6), Qubit(2)])  # |010101>
+        mps.apply_unitary(cx, [Qubit(6), Qubit(3)])  # |010111>
+        # Add another qubit at the end of the MPS
+        mps.add_qubit(new_qubit=Qubit(5), position=len(mps), state=1)  # |0101111>
+        # Apply some more gates acting on the new qubit
+        mps.apply_unitary(cx, [Qubit(4), Qubit(5)])  # |0101110>
+
+        # The resulting state should be |0101110>
+        sv = np.zeros(2**7)
+        sv[int("0101110", 2)] = 1
+
+        # However, since mps.get_statevector will sort qubits in ILO, the bits would
+        # change position. Instead, we can relabel the qubits.
+        mps.apply_qubit_relabelling(
+            {q: Qubit(i) for q, i in mps.qubit_position.items()}
+        )
+
+        # Compare the state vectors
+        assert np.allclose(mps.get_statevector(), sv)
+
+        # Measure some of the qubits destructively
+        outcomes = mps.measure({Qubit(0), Qubit(2), Qubit(4)}, destructive=True)
+        # Since the state is |0101110>, the outcomes are deterministic
+        assert outcomes[Qubit(0)] == 0
+        assert outcomes[Qubit(2)] == 0
+        assert outcomes[Qubit(4)] == 1
+
+        # Note that the qubit identifiers have not been updated,
+        # so the qubits that were measured are no longer in the MPS.
+        with pytest.raises(ValueError, match="not a qubit in the MPS"):
+            mps.measure({Qubit(0)})
+
+        # Measure some of the remaining qubits non-destructively
+        outcomes = mps.measure({Qubit(1), Qubit(6)}, destructive=False)
+        assert outcomes[Qubit(1)] == 1
+        assert outcomes[Qubit(6)] == 0
+
+        # The resulting state should be |1110>, verify it
+        sv = np.zeros(2**4)
+        sv[int("1110", 2)] = 1
+        assert np.allclose(mps.get_statevector(), sv)
+
+        # Apply a few more gates to check it works
+        mps.apply_unitary(x, [Qubit(1)])  # |0110>
+        mps.apply_unitary(cx, [Qubit(3), Qubit(5)])  # |0100>
+
+        # The resulting state should be |0100>, verify it
+        sv = np.zeros(2**4)
+        sv[int("0100", 2)] = 1
+        assert np.allclose(mps.get_statevector(), sv)
+


### PR DESCRIPTION
# Description

- New feature: ``add_qubit`` to add fresh qubits at specified positions in an ``MPS``.
- New feature: added an option to ``measure`` to toggle destructive measurement on/off. Currently only supported for ``MPS``. 

# Related issues

Non-destructive measurements are required for PECOS integration. These use ``add_qubit`` internally.

# Checklist

- [x] I have run the tests on a device with GPUs.
- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
