### PR TITLE
Support general matrix elements in backend

### DIFF
--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -312,7 +312,7 @@ class CuTensorNetBackend(Backend):
             )  # This needed because dagger does not work with post selection
 
         for qos, coeff in operator._dict.items():
-            element_value_network = ExpectationValueTensorNetwork(
+            element_network = ExpectationValueTensorNetwork(
                 bra_network, qos, ket_network
             )
             if isinstance(coeff, Expr):
@@ -320,7 +320,7 @@ class CuTensorNetBackend(Backend):
             else:
                 numeric_coeff = complex(coeff)  # type: ignore
             element_term = numeric_coeff * cq.contract(
-                *element_value_network.cuquantum_interleaved
+                *element_network.cuquantum_interleaved
             )
             element += element_term
         return element.real

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -265,7 +265,7 @@ class CuTensorNetBackend(Backend):
             operator,
             post_selection=post_selection,
             valid_check=valid_check,
-        )
+        ).real
 
     # TODO: this should be optionally parallelised with MPI
     #  (both wrt Pauli strings and contraction itself).
@@ -323,7 +323,7 @@ class CuTensorNetBackend(Backend):
                 *element_network.cuquantum_interleaved
             )
             element += element_term
-        return element.real
+        return element
 
     def get_circuit_overlap(
         self,

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -297,8 +297,8 @@ class CuTensorNetBackend(Backend):
 
         element = 0
 
-        bra_network = TensorNetwork(circuit_bra)
-        ket_network = TensorNetwork(circuit_ket).dagger()
+        ket_network = TensorNetwork(circuit_ket)
+        bra_network = TensorNetwork(circuit_bra).dagger()
 
         if post_selection is not None:
             post_select_qubits = list(post_selection.keys())

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -298,7 +298,7 @@ class CuTensorNetBackend(Backend):
         element = 0
 
         bra_network = TensorNetwork(circuit_bra)
-        ket_network = TensorNetwork(circuit_ket)
+        ket_network = TensorNetwork(circuit_ket).dagger()
 
         if post_selection is not None:
             post_select_qubits = list(post_selection.keys())


### PR DESCRIPTION
# Description

Adds a function to `CuTensorNetBackend` to get general matrix elements. Expectation values are computed as a special case of that function.

I've not added tests as of now, as my understanding as per @PabloAndresCQ is that this is soon to be refactored anyway, so this PR may become defunct.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have run the tests on a device with GPUs.
- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
