### PR TITLE
Restore old docs and workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -132,3 +132,23 @@ jobs:
         cd .github/workflows/docs
         mkdir extensions
         ./build-docs -d ${GITHUB_WORKSPACE}/.github/workflows/docs/extensions/api
+    - name: Upload docs as artefact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: .github/workflows/docs/extensions
+
+  publish_docs:
+    name: Publish docs
+    if: github.event_name == 'release'
+    needs: build_docs
+    runs-on: ubuntu-22.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4.0.5

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently, only single-GPU calculations are supported, but a multi-GPU execution
 implemented in the due course using `mpi4py` library.
 
 Some useful links:
-- [API Documentation](https://tket.quantinuum.com/extensions/pytket-cutensornet/)
+- [API Documentation](https://cqcl.github.io/pytket-cutensornet/api/index.html)
 
 ## Getting started
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,6 @@ Changelog
 0.7.0 (July 2024)
 -----------------
 
-* Updated pytket version requirement to 1.30.
 * API breaking changes
     * Renamed ``CuTensorNetBackend`` to ``CuTensorNetStateBackend``.
     * Moved ``get_operator_expectation_value`` and ``get_circuit_overlap`` from ``backends`` submodule to ``general_state`` submodule.
@@ -18,6 +17,7 @@ Changelog
 * New feature: a seed can now be provided to ``Config`` objects, providing reproducibility across ``StructuredState`` simulations.
 * New feature: ``apply_unitary`` both for ``MPS`` and ``TTN`` to apply an arbitrary unitary matrix, rather than a ``pytket.Command``.
 * New feature: ``apply_qubit_relabelling`` both for ``MPS`` and ``TTN`` to change the name of their qubits. This is now used within ``simulate`` to take into account the action of implicit SWAPs in pytket circuits (no additional SWAP gates are applied).
+* Updated pytket version requirement to 1.30.
 
 0.6.1 (April 2024)
 ------------------


### PR DESCRIPTION
# Description

There's some problems with the new version of docs (listed in the linked issue). As such, for now `pytket-cutensornet` will continue maintaining the old version of the docs, and using it as the main version. Once these issues are solved, I'm happy to make another release switching to the new docs.

# Related issues

#139 

# Checklist

- [ ] I have run the tests on a device with GPUs.
- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
