### PR TITLE
[feature] Backend options

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-* Backend methods can now be given `cutn_attributes` and `scratch_fraction` arguments to configure the cuTensorNet contraction.
+* Backend methods can now be given a ``scratch_fraction`` argument to configure the amount of GPU memory allocated to cuTensorNet contraction. Users can also configure the values of the ``StateAttribute`` and ``SamplerAttribute`` from cuTensornet via the backend interface.
 * Fixed a bug causing the logger to fail displaying device properties.
 
 0.7.0 (July 2024)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+* Backend methods can now be given `cutn_attributes` and `scratch_fraction` arguments to configure the cuTensorNet contraction.
 * Fixed a bug causing the logger to fail displaying device properties.
 
 0.7.0 (July 2024)

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -15,6 +15,7 @@
 """Methods to allow tket circuits to be run on the cuTensorNet simulator."""
 
 from abc import abstractmethod
+import warnings
 
 from typing import List, Union, Optional, Sequence
 from uuid import uuid4
@@ -44,7 +45,12 @@ from pytket.passes import (  # type: ignore
     FullPeepholeOptimise,
     CustomPass,
 )
-from cuquantum.cutensornet import StateAttribute, SamplerAttribute  # type: ignore
+
+try:
+    from cuquantum.cutensornet import StateAttribute, SamplerAttribute  # type: ignore
+except ImportError:
+    warnings.warn("local settings failed to import cuquantum", ImportWarning)
+
 from .._metadata import __extension_version__, __extension_name__
 
 

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -197,7 +197,9 @@ class CuTensorNetStateBackend(_CuTensorNetBaseBackend):
         corresponding get_<data> method.
 
         Note:
-            TODO: Mention cutn attributes.
+            Any element from the ``StateAttribute`` enum (see NVIDIA's CuTensorNet
+            API) can be provided as arguments to this method. For instance:
+            ``process_circuits(..., CONFIG_NUM_HYPER_SAMPLES=100)``.
 
         Args:
             circuits: List of circuits to be submitted.
@@ -270,6 +272,11 @@ class CuTensorNetShotsBackend(_CuTensorNetBaseBackend):
 
         The results will be stored in the backend's result cache to be retrieved by the
         corresponding get_<data> method.
+
+        Note:
+            Any element from the ``SamplerAttribute`` enum (see NVIDIA's CuTensorNet
+            API) can be provided as arguments to this method. For instance:
+            ``process_circuits(..., CONFIG_NUM_HYPER_SAMPLES=100)``.
 
         Args:
             circuits: List of circuits to be submitted.

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -44,6 +44,7 @@ from pytket.passes import (  # type: ignore
     FullPeepholeOptimise,
     CustomPass,
 )
+from cuquantum.cutensornet import StateAttribute, SamplerAttribute  # type: ignore
 from .._metadata import __extension_version__, __extension_name__
 
 
@@ -195,15 +196,25 @@ class CuTensorNetStateBackend(_CuTensorNetBaseBackend):
         The results will be stored in the backend's result cache to be retrieved by the
         corresponding get_<data> method.
 
+        Note:
+            TODO: Mention cutn attributes.
+
         Args:
             circuits: List of circuits to be submitted.
             n_shots: Number of shots in case of shot-based calculation.
                 This should be ``None``, since this backend does not support shots.
             valid_check: Whether to check for circuit correctness.
+            scratch_fraction: Optional. Fraction of free memory on GPU to allocate as
+                scratch space. Defaults to `0.75`.
 
         Returns:
             Results handle objects.
         """
+        scratch_fraction = float(kwargs.get("scratch_fraction", 0.75))  # type: ignore
+        cutn_attributes = {
+            k: v for k, v in kwargs.items() if k in StateAttribute._member_names_
+        }
+
         circuit_list = list(circuits)
         if valid_check:
             self._check_all_circuits(circuit_list)
@@ -211,7 +222,7 @@ class CuTensorNetStateBackend(_CuTensorNetBaseBackend):
         with CuTensorNetHandle() as libhandle:
             for circuit in circuit_list:
                 tn = GeneralState(circuit, libhandle)
-                sv = tn.get_statevector()
+                sv = tn.get_statevector(cutn_attributes, scratch_fraction)
                 res_qubits = [qb for qb in sorted(circuit.qubits)]
                 handle = ResultHandle(str(uuid4()))
                 self._cache[handle] = {
@@ -266,10 +277,17 @@ class CuTensorNetShotsBackend(_CuTensorNetBaseBackend):
                 Optionally, this can be a list of shots specifying the number of shots
                 for each circuit separately.
             valid_check: Whether to check for circuit correctness.
+            scratch_fraction: Optional. Fraction of free memory on GPU to allocate as
+                scratch space. Defaults to `0.75`.
 
         Returns:
             Results handle objects.
         """
+        scratch_fraction = float(kwargs.get("scratch_fraction", 0.75))  # type: ignore
+        cutn_attributes = {
+            k: v for k, v in kwargs.items() if k in SamplerAttribute._member_names_
+        }
+
         if "seed" in kwargs and kwargs["seed"] is not None:
             # Current CuTensorNet does not support seeds for Sampler. I created
             # a feature request in their repository.
@@ -294,7 +312,9 @@ class CuTensorNetShotsBackend(_CuTensorNetBaseBackend):
             for circuit, circ_shots in zip(circuit_list, all_shots):
                 tn = GeneralState(circuit, libhandle)
                 handle = ResultHandle(str(uuid4()))
-                self._cache[handle] = {"result": tn.sample(circ_shots)}
+                self._cache[handle] = {
+                    "result": tn.sample(circ_shots, cutn_attributes, scratch_fraction)
+                }
                 handle_list.append(handle)
         return handle_list
 

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -219,7 +219,7 @@ class CuTensorNetStateBackend(_CuTensorNetBaseBackend):
             Results handle objects.
         """
         scratch_fraction = float(kwargs.get("scratch_fraction", 0.75))  # type: ignore
-        cutn_attributes = {
+        attributes = {
             k: v for k, v in kwargs.items() if k in StateAttribute._member_names_
         }
 
@@ -230,7 +230,7 @@ class CuTensorNetStateBackend(_CuTensorNetBaseBackend):
         with CuTensorNetHandle() as libhandle:
             for circuit in circuit_list:
                 tn = GeneralState(circuit, libhandle)
-                sv = tn.get_statevector(cutn_attributes, scratch_fraction)
+                sv = tn.get_statevector(attributes, scratch_fraction)
                 res_qubits = [qb for qb in sorted(circuit.qubits)]
                 handle = ResultHandle(str(uuid4()))
                 self._cache[handle] = {
@@ -297,7 +297,7 @@ class CuTensorNetShotsBackend(_CuTensorNetBaseBackend):
             Results handle objects.
         """
         scratch_fraction = float(kwargs.get("scratch_fraction", 0.75))  # type: ignore
-        cutn_attributes = {
+        attributes = {
             k: v for k, v in kwargs.items() if k in SamplerAttribute._member_names_
         }
 
@@ -326,7 +326,7 @@ class CuTensorNetShotsBackend(_CuTensorNetBaseBackend):
                 tn = GeneralState(circuit, libhandle)
                 handle = ResultHandle(str(uuid4()))
                 self._cache[handle] = {
-                    "result": tn.sample(circ_shots, cutn_attributes, scratch_fraction)
+                    "result": tn.sample(circ_shots, attributes, scratch_fraction)
                 }
                 handle_list.append(handle)
         return handle_list

--- a/pytket/extensions/cutensornet/general_state/tensor_network_state.py
+++ b/pytket/extensions/cutensornet/general_state/tensor_network_state.py
@@ -113,14 +113,14 @@ class GeneralState:
 
     def get_statevector(
         self,
-        cutn_attributes: Optional[dict] = None,
+        attributes: Optional[dict] = None,
         scratch_fraction: float = 0.75,
         on_host: bool = True,
     ) -> Union[cp.ndarray, np.ndarray]:
         """Contracts the circuit and returns the final statevector.
 
         Args:
-            cutn_attributes: Optional. A dict of cuTensorNet `StateAttribute` keys and
+            attributes: Optional. A dict of cuTensorNet `StateAttribute` keys and
                 their values.
             scratch_fraction: Optional. Fraction of free memory on GPU to allocate as
                 scratch space.
@@ -136,10 +136,10 @@ class GeneralState:
         ####################################
         # Configure the TN for contraction #
         ####################################
-        if cutn_attributes is None:
-            cutn_attributes = dict()
+        if attributes is None:
+            attributes = dict()
         attribute_pairs = [
-            (getattr(cutn.StateAttribute, k), v) for k, v in cutn_attributes.items()
+            (getattr(cutn.StateAttribute, k), v) for k, v in attributes.items()
         ]
 
         for attr, val in attribute_pairs:
@@ -228,14 +228,14 @@ class GeneralState:
     def expectation_value(
         self,
         operator: QubitPauliOperator,
-        cutn_attributes: Optional[dict] = None,
+        attributes: Optional[dict] = None,
         scratch_fraction: float = 0.75,
     ) -> complex:
         """Calculates the expectation value of the given operator.
 
         Args:
             operator: The operator whose expectation value is to be measured.
-            cutn_attributes: Optional. A dict of cuTensorNet `ExpectationAttribute` keys
+            attributes: Optional. A dict of cuTensorNet `ExpectationAttribute` keys
                 and their values.
             scratch_fraction: Optional. Fraction of free memory on GPU to allocate as
                  scratch space.
@@ -310,11 +310,10 @@ class GeneralState:
             self._lib.handle, self._state, tn_operator
         )
 
-        if cutn_attributes is None:
-            cutn_attributes = dict()
+        if attributes is None:
+            attributes = dict()
         attribute_pairs = [
-            (getattr(cutn.ExpectationAttribute, k), v)
-            for k, v in cutn_attributes.items()
+            (getattr(cutn.ExpectationAttribute, k), v) for k, v in attributes.items()
         ]
 
         for attr, val in attribute_pairs:
@@ -407,14 +406,14 @@ class GeneralState:
     def sample(
         self,
         n_shots: int,
-        cutn_attributes: Optional[dict] = None,
+        attributes: Optional[dict] = None,
         scratch_fraction: float = 0.75,
     ) -> BackendResult:
         """Obtains samples from the measurements at the end of the circuit.
 
         Args:
             n_shots: The number of samples to obtain.
-            cutn_attributes: Optional. A dict of cuTensorNet `SamplerAttribute` keys and
+            attributes: Optional. A dict of cuTensorNet `SamplerAttribute` keys and
                 their values.
             scratch_fraction: Optional. Fraction of free memory on GPU to allocate as
                 scratch space.
@@ -447,10 +446,10 @@ class GeneralState:
             modes_to_sample=measured_modes,
         )
 
-        if cutn_attributes is None:
-            cutn_attributes = dict()
+        if attributes is None:
+            attributes = dict()
         attribute_pairs = [
-            (getattr(cutn.SamplerAttribute, k), v) for k, v in cutn_attributes.items()
+            (getattr(cutn.SamplerAttribute, k), v) for k, v in attributes.items()
         ]
 
         for attr, val in attribute_pairs:

--- a/pytket/extensions/cutensornet/general_state/tensor_network_state.py
+++ b/pytket/extensions/cutensornet/general_state/tensor_network_state.py
@@ -419,12 +419,17 @@ class GeneralState:
             scratch_fraction: Optional. Fraction of free memory on GPU to allocate as
                 scratch space.
         Raises:
+            ValueError: If the circuit contains no measurements.
             MemoryError: If there is insufficient workspace on GPU.
         Returns:
             A pytket ``BackendResult`` with the data from the shots.
         """
 
         num_measurements = len(self._measurements)
+        if num_measurements == 0:
+            raise ValueError(
+                "Cannot sample from the circuit, it contains no measurements."
+            )
         # We will need both a list of the qubits and a list of the classical bits
         # and it is essential that the elements in the same index of either list
         # match according to the self._measurements map. We guarantee this here.

--- a/pytket/extensions/cutensornet/general_state/tensor_network_state.py
+++ b/pytket/extensions/cutensornet/general_state/tensor_network_state.py
@@ -44,7 +44,7 @@ class GeneralState:
         self,
         circuit: Circuit,
         libhandle: CuTensorNetHandle,
-        loglevel: int = logging.INFO,
+        loglevel: int = logging.WARNING,
     ) -> None:
         """Constructs a tensor network for the output state of a pytket circuit.
 
@@ -113,14 +113,14 @@ class GeneralState:
 
     def get_statevector(
         self,
-        attributes: Optional[dict] = None,
-        scratch_fraction: float = 0.5,
+        cutn_attributes: Optional[dict] = None,
+        scratch_fraction: float = 0.75,
         on_host: bool = True,
     ) -> Union[cp.ndarray, np.ndarray]:
         """Contracts the circuit and returns the final statevector.
 
         Args:
-            attributes: Optional. A dict of cuTensorNet `StateAttribute` keys and
+            cutn_attributes: Optional. A dict of cuTensorNet `StateAttribute` keys and
                 their values.
             scratch_fraction: Optional. Fraction of free memory on GPU to allocate as
                 scratch space.
@@ -136,10 +136,10 @@ class GeneralState:
         ####################################
         # Configure the TN for contraction #
         ####################################
-        if attributes is None:
-            attributes = dict()
+        if cutn_attributes is None:
+            cutn_attributes = dict()
         attribute_pairs = [
-            (getattr(cutn.StateAttribute, k), v) for k, v in attributes.items()
+            (getattr(cutn.StateAttribute, k), v) for k, v in cutn_attributes.items()
         ]
 
         for attr, val in attribute_pairs:
@@ -228,14 +228,14 @@ class GeneralState:
     def expectation_value(
         self,
         operator: QubitPauliOperator,
-        attributes: Optional[dict] = None,
-        scratch_fraction: float = 0.5,
+        cutn_attributes: Optional[dict] = None,
+        scratch_fraction: float = 0.75,
     ) -> complex:
         """Calculates the expectation value of the given operator.
 
         Args:
             operator: The operator whose expectation value is to be measured.
-            attributes: Optional. A dict of cuTensorNet `ExpectationAttribute` keys
+            cutn_attributes: Optional. A dict of cuTensorNet `ExpectationAttribute` keys
                 and their values.
             scratch_fraction: Optional. Fraction of free memory on GPU to allocate as
                  scratch space.
@@ -310,10 +310,11 @@ class GeneralState:
             self._lib.handle, self._state, tn_operator
         )
 
-        if attributes is None:
-            attributes = dict()
+        if cutn_attributes is None:
+            cutn_attributes = dict()
         attribute_pairs = [
-            (getattr(cutn.ExpectationAttribute, k), v) for k, v in attributes.items()
+            (getattr(cutn.ExpectationAttribute, k), v)
+            for k, v in cutn_attributes.items()
         ]
 
         for attr, val in attribute_pairs:
@@ -406,14 +407,14 @@ class GeneralState:
     def sample(
         self,
         n_shots: int,
-        attributes: Optional[dict] = None,
-        scratch_fraction: float = 0.5,
+        cutn_attributes: Optional[dict] = None,
+        scratch_fraction: float = 0.75,
     ) -> BackendResult:
         """Obtains samples from the measurements at the end of the circuit.
 
         Args:
             n_shots: The number of samples to obtain.
-            attributes: Optional. A dict of cuTensorNet `SamplerAttribute` keys and
+            cutn_attributes: Optional. A dict of cuTensorNet `SamplerAttribute` keys and
                 their values.
             scratch_fraction: Optional. Fraction of free memory on GPU to allocate as
                 scratch space.
@@ -441,10 +442,10 @@ class GeneralState:
             modes_to_sample=measured_modes,
         )
 
-        if attributes is None:
-            attributes = dict()
+        if cutn_attributes is None:
+            cutn_attributes = dict()
         attribute_pairs = [
-            (getattr(cutn.SamplerAttribute, k), v) for k, v in attributes.items()
+            (getattr(cutn.SamplerAttribute, k), v) for k, v in cutn_attributes.items()
         ]
 
         for attr, val in attribute_pairs:


### PR DESCRIPTION
# Description

- Solves the issue below, allowing users to provide attributes from the cuTensorNet enums.
- Adds a check in `sample` from `GeneralState` to raise an exception if the circuit has no measurements.
- Small changes:
  - Default `scratch_fraction` is now 0.75
  - Set the default logging level of `GeneralState` to WARNING (less verbose than INFO)

# Related issues

Solves #144 

# Checklist

- [x] I have run the tests on a device with GPUs.
- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
