### PR TITLE
Update cutensornet and cutensor in nix flake

### DIFF
--- a/nix-support/cuquantum.nix
+++ b/nix-support/cuquantum.nix
@@ -8,26 +8,26 @@
   #cuda-bundle,
 }:
 let
-  version = "24.03.0.4";
+  version = "24.08.0.5";
   package_map = {
     x86_64-linux = {
       "11" = fetchzip {
         url = "https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-x86_64/cuquantum-linux-x86_64-${version}_cuda11-archive.tar.xz";
-        sha256 = sha256:tvUEKdUp3dluY7uzm6NJBZxcjJsVhMtwJmV061vR0XU=;
+        sha256 = sha256:FPrmmOccmQynFKo5A49B5k6iGZBwgpTR6JEK/kREY7E=;
       };
       "12" = fetchzip {
         url = "https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-x86_64/cuquantum-linux-x86_64-${version}_cuda12-archive.tar.xz";
-        sha256 = sha256:ws9dPv4Tkdu9XSE4zI3WdFccQuhiycrEchduzPNBiCc=;
+        sha256 = sha256:nNv/oon6QNMMX3kQ+7pJXzzagfwHx+p9nvq9Q7H2/e8=;
       };
     };
     aarch64-linux = {
       "11" = fetchzip {
         url = "https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-sbsa/cuquantum-linux-sbsa-${version}_cuda11-archive.tar.xz";
-        sha256 = sha256:Wc0HgfnDgTpyDKMQpnJdJ95FkBe+7XAqQ48XkkrWiKU=;
+        sha256 = sha256:oYgBYgN4F8JJW5E6DdoffaktIXvqHf3cW9J9SXjBQiE=;
       };
       "12" = fetchzip {
         url = "https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-sbsa/cuquantum-linux-sbsa-${version}_cuda12-archive.tar.xz";
-        sha256 = sha256:ZnjnMja0565Mi9GE6IE3uDXXY1jisz/VS1Yl7nZSaVw=;
+        sha256 = sha256:gzNYunkA6qLrVj7Put0o8WEjaPkUPE6kbnxEKKCMWS8=;
       };
     };
   };
@@ -42,9 +42,4 @@ in
       cp -r $src/* $out
       chmod -R 0755 $out
     '';
-    #fixupPhase = ''
-    #  for f in $out/lib/*.so; do
-    #    patchelf --set-rpath ${cuda-bundle}/lib $f;
-    #  done;
-    #'';
   }

--- a/nix-support/cutensor.nix
+++ b/nix-support/cutensor.nix
@@ -2,17 +2,17 @@
 let
   package_map = {
     x86_64-linux = fetchzip {
-      url = "https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.0.1.2-archive.tar.xz";
-      sha256 = sha256:OPn5577DBwzcGdSovv5tMv+x3wW2QgF5XVmRgm5y148=;
+      url = "https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.0.2.5-archive.tar.xz";
+      sha256 = sha256:06ygtOh3potihT0bm0lhytKpf7zWOA8Ap9rATNvQdTk=;
     };
     aarch64-linux = fetchzip {
-      url = "https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.0.1.2-archive.tar.xz";
-      sha256 = sha256:vTEQ7uJYrEC1Q55DgCO5/PXTm0f34ndqezotnqq6E00=;
+      url = "https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.0.2.5-archive.tar.xz";
+      sha256 = sha256:CRewkAlXYklDnj6iF6eGv0C8yxHVDOdj+mXqm2dN+po=;
     };
   };
 in pkgs.stdenv.mkDerivation {
   pname = "libcutensor";
-  version = "2.0.1.2";
+  version = "2.0.2.5";
   outputs = [ "out" "lib" "dev" "static" ];
   src = package_map.${pkgs.system};
   installPhase = let

--- a/nix-support/pycuquantum.nix
+++ b/nix-support/pycuquantum.nix
@@ -11,13 +11,13 @@
 }:
 buildPythonPackage{
   pname = "cuquantum";
-  version = "24.03.0";
+  version = "24.08.0";
   pyproject = true;
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "cuQuantum";
-    rev = "v24.03.0";
-    sha256 = sha256:1GPotBCNEsriU+yrWQpIVWKh/wEK8EPWYjn3jF4w8T0=;
+    rev = "v24.08.0";
+    sha256 = sha256:cOWj8I/pAfTuW2qmV75juj5T9UkBhz6xRa0+1KxKo18=;
   };
   patches = [
     (substituteAll {

--- a/nix-support/pycuquantum.patch
+++ b/nix-support/pycuquantum.patch
@@ -41,7 +41,7 @@ index cd54946..e46633e 100644
  cdef void* load_library() except* nogil:
      cdef void* handle
 -    handle = dlopen("libcutensornet.so.2", RTLD_NOW | RTLD_GLOBAL)
-+    handle = dlopen("@cuda_bundle/lib/libcutensornet.so.2", RTLD_NOW | RTLD_GLOBAL)
++    handle = dlopen("@cuda_bundle@/lib/libcutensornet.so.2", RTLD_NOW | RTLD_GLOBAL)
      if handle == NULL:
          with gil:
              err_msg = dlerror()

--- a/nix-support/pycuquantum.patch
+++ b/nix-support/pycuquantum.patch
@@ -1,5 +1,5 @@
 diff --git a/builder/pep517.py b/builder/pep517.py
-index ce701e4..8b99806 100644
+index 0916ab7..0430abf 100644
 --- a/builder/pep517.py
 +++ b/builder/pep517.py
 @@ -30,11 +30,12 @@ def get_requires_for_build_wheel(config_settings=None):
@@ -7,10 +7,10 @@ index ce701e4..8b99806 100644
      # 22.3 by setuptools, so we must follow the same practice in the constraints;
      # also, we don't need the patch number here
 -    cuqnt_require = [f'custatevec-cu{utils.cuda_major_ver}~=1.6',   # ">=1.6.0,<2"
--                     f'cutensornet-cu{utils.cuda_major_ver}~=2.4',  # ">=2.4.0,<3"
+-                     f'cutensornet-cu{utils.cuda_major_ver}~=2.5',   # ">=2.5.0,<3"
 -                    ]
 +    #cuqnt_require = [f'custatevec-cu{utils.cuda_major_ver}~=1.6',   # ">=1.6.0,<2"
-+    #                 f'cutensornet-cu{utils.cuda_major_ver}~=2.4',  # ">=2.4.0,<3"
++    #                 f'cutensornet-cu{utils.cuda_major_ver}~=2.5',   # ">=2.5.0,<3"
 +    #                ]
  
 -    return _build_meta.get_requires_for_build_wheel(config_settings) + cuqnt_require
@@ -20,20 +20,20 @@ index ce701e4..8b99806 100644
  
  # Note: We have never promised to support sdist (CUQNT-514). We really cannot
 diff --git a/cuquantum/custatevec/_internal/custatevec_linux.pyx b/cuquantum/custatevec/_internal/custatevec_linux.pyx
-index 8b918ca..afc6d87 100644
+index e3334c4..3309ac9 100644
 --- a/cuquantum/custatevec/_internal/custatevec_linux.pyx
 +++ b/cuquantum/custatevec/_internal/custatevec_linux.pyx
-@@ -111,7 +111,7 @@ cdef void* __custatevecSubSVMigratorMigrate = NULL
+@@ -111,7 +111,7 @@ cdef void* __custatevecComputeExpectationBatched = NULL
  
  cdef void* load_library() except* nogil:
      cdef void* handle
 -    handle = dlopen("libcustatevec.so.1", RTLD_NOW | RTLD_GLOBAL)
-+    handle = dlopen("@cuda_bundle@/lib/libcustatevec.so", RTLD_NOW | RTLD_GLOBAL)
++    handle = dlopen("@cuda_bundle@/lib/libcustatevec.so.1", RTLD_NOW | RTLD_GLOBAL)
      if handle == NULL:
          with gil:
              err_msg = dlerror()
 diff --git a/cuquantum/cutensornet/_internal/cutensornet_linux.pyx b/cuquantum/cutensornet/_internal/cutensornet_linux.pyx
-index b63a366..1143833 100644
+index cd54946..e46633e 100644
 --- a/cuquantum/cutensornet/_internal/cutensornet_linux.pyx
 +++ b/cuquantum/cutensornet/_internal/cutensornet_linux.pyx
 @@ -152,7 +152,7 @@ cdef void* __cutensornetSamplerGetInfo = NULL
@@ -41,22 +41,22 @@ index b63a366..1143833 100644
  cdef void* load_library() except* nogil:
      cdef void* handle
 -    handle = dlopen("libcutensornet.so.2", RTLD_NOW | RTLD_GLOBAL)
-+    handle = dlopen("@cuda_bundle@/lib/libcutensornet.so", RTLD_NOW | RTLD_GLOBAL)
++    handle = dlopen("@cuda_bundle/lib/libcutensornet.so.2", RTLD_NOW | RTLD_GLOBAL)
      if handle == NULL:
          with gil:
              err_msg = dlerror()
 diff --git a/setup.py b/setup.py
-index 47a892f..11f59db 100644
+index 43d1080..2eb981c 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -35,8 +35,8 @@ with open(os.path.join(source_root, "tests/requirements.txt")) as f:
  install_requires = [
-     'numpy~=1.21',  # ">=1.21,<2"
+     'numpy>=1.21, <3.0',  # ">=1.21,<3"
      # 'torch', # <-- PyTorch is optional; also, the PyPI version does not support GPU...
 -    f'custatevec-cu{utils.cuda_major_ver}~=1.6',   # ">=1.6.0,<2"
--    f'cutensornet-cu{utils.cuda_major_ver}~=2.4',  # ">=2.4.0,<3"
+-    f'cutensornet-cu{utils.cuda_major_ver}>=2.5.0,<3',
 +    #f'custatevec-cu{utils.cuda_major_ver}~=1.6',   # ">=1.6.0,<2"
-+    #f'cutensornet-cu{utils.cuda_major_ver}~=2.4',  # ">=2.4.0,<3"
++    #f'cutensornet-cu{utils.cuda_major_ver}>=2.5.0,<3',
  ]
  if utils.cuda_major_ver == '11':
      install_requires.append('cupy-cuda11x>=13.0')  # no ambiguity


### PR DESCRIPTION
# Description

Cutensornet is now at `24.08.0.5`
Cutensor is now at `2.0.2.5`

I have tested feat/network_state rebased onto this and all tests pass.

# Related issues

N/A

# Checklist

- [x] I have run the tests on a device with GPUs.
- [x] I have performed a self-review of my code.