### PR TITLE
Remove unnecessary canonicalisation steps before non-adjacent two-qubit gates

### DIFF
--- a/pytket/extensions/cutensornet/structured_state/mps_gate.py
+++ b/pytket/extensions/cutensornet/structured_state/mps_gate.py
@@ -234,7 +234,7 @@ class MPSxGate(MPS):
 
         # Always canonicalise. Even in the case of exact simulation (no truncation)
         # canonicalisation may reduce the bond dimension (thanks to reduced QR).
-        self.canonicalise(l_pos, l_pos)
+        self.canonicalise(l_pos, r_pos)
 
         # Reshape into a rank-4 tensor
         gate_tensor = cp.reshape(unitary, (2, 2, 2, 2))


### PR DESCRIPTION
No need to canonicalise all the way to `l_pos`, you just need that everything left of `l_pos` is in left canonical form and everything to the right of `r_pos` in right canonical form.