### PR TITLE
Constrain to pytket 1.x.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket >= 1.39.0",
+        "pytket >= 1.39.0, < 2",
         "networkx >= 2.8.8",
     ],
     classifiers=[


### PR DESCRIPTION
When we release pytket 2.0 the `ClassicalExpBox` and `add_classicalexpbox_{bit,register}` will disappear. After that it should be a simple matter to update the requirement to ">= 2.0.0" and remove the handling of, and tests involving, `ClassicalExpBox` in this repo.