### PR TITLE
[feature] Allow users to specify file to write log on

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 ~~~~~~~~~
 
+0.11.0 (unreleased)
+-------------------
+
+* A logfile can now be specified, as an alternative to printing the log to stream.
+
 0.10.2 (February 2025)
 ----------------------
 

--- a/pytket/extensions/cutensornet/general.py
+++ b/pytket/extensions/cutensornet/general.py
@@ -113,9 +113,9 @@ def set_logger(
     logger.propagate = False
     if not logger.handlers:
         if file is None:
-            handler = logging.StreamHandler()
+            handler = logging.StreamHandler()  # type: ignore
         else:
-            handler = logging.FileHandler(file)
+            handler = logging.FileHandler(file)  # type: ignore
         handler.setLevel(level)
         formatter = logging.Formatter(fmt, datefmt="%H:%M:%S")
         handler.setFormatter(formatter)

--- a/pytket/extensions/cutensornet/general.py
+++ b/pytket/extensions/cutensornet/general.py
@@ -111,13 +111,14 @@ def set_logger(
     logger = logging.getLogger(logger_name)
     logger.setLevel(level)
     logger.propagate = False
-    if not logger.handlers:
-        if file is None:
-            handler = logging.StreamHandler()  # type: ignore
-        else:
-            handler = logging.FileHandler(file)  # type: ignore
-        handler.setLevel(level)
-        formatter = logging.Formatter(fmt, datefmt="%H:%M:%S")
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
+
+    handler: logging.StreamHandler
+    if file is None:
+        handler = logging.StreamHandler()
+    else:
+        handler = logging.FileHandler(file)
+    handler.setLevel(level)
+    formatter = logging.Formatter(fmt, datefmt="%H:%M:%S")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
     return logger

--- a/pytket/extensions/cutensornet/general.py
+++ b/pytket/extensions/cutensornet/general.py
@@ -94,6 +94,7 @@ class CuTensorNetHandle:
 def set_logger(
     logger_name: str,
     level: int = logging.WARNING,
+    file: Optional[str] = None,
     fmt: str = "[%(asctime)s.%(msecs)03d] %(name)s (%(levelname)s) - %(message)s",
 ) -> Logger:
     """Initialises and configures a logger object.
@@ -101,6 +102,7 @@ def set_logger(
     Args:
         logger_name: Name for the logger object.
         level: Logger output level.
+        file: File to write the log on.
         fmt: Logger output format.
 
     Returns:
@@ -110,7 +112,10 @@ def set_logger(
     logger.setLevel(level)
     logger.propagate = False
     if not logger.handlers:
-        handler = logging.StreamHandler()
+        if file is None:
+            handler = logging.StreamHandler()
+        else:
+            handler = logging.FileHandler(file)
         handler.setLevel(level)
         formatter = logging.Formatter(fmt, datefmt="%H:%M:%S")
         handler.setFormatter(formatter)

--- a/pytket/extensions/cutensornet/general_state/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/general_state/tensor_network_convert.py
@@ -43,7 +43,7 @@ class TensorNetwork:
     """Responsible for converting pytket circuit to a tensor network and handling it."""
 
     def __init__(
-        self, circuit: Circuit, adj: bool = False, loglevel: int = logging.INFO
+        self, circuit: Circuit, adj: bool = False, loglevel: int = logging.INFO, logfile: Optional[str] = None
     ) -> None:
         """Constructs a tensor network from a pytket circuit.
 
@@ -53,11 +53,12 @@ class TensorNetwork:
             circuit: A pytket circuit to be converted to a tensor network.
             adj: Whether to create an adjoint representation of the original circuit.
             loglevel: Internal logger output level.
+            logfile: If provided, log is written to this file rather than stream.
 
         Raises:
             RuntimeError: If ``Box`` objects are present in the circuit.
         """
-        self._logger = set_logger("TensorNetwork", loglevel)
+        self._logger = set_logger("TensorNetwork", level=loglevel, file=logfile)
         self._circuit = circuit
         # self._circuit.replace_implicit_wire_swaps()
         self._qubit_names_ilo = [str(q) for q in self._circuit.qubits]
@@ -555,6 +556,7 @@ class PauliOperatorTensorNetwork:
         bra: TensorNetwork,
         ket: TensorNetwork,
         loglevel: int = logging.INFO,
+        logfile: Optional[str] = None,
     ) -> None:
         """Constructs a tensor network representing a Pauli operator string.
 
@@ -570,8 +572,9 @@ class PauliOperatorTensorNetwork:
             bra: Tensor network object representing a bra circuit.
             ket: Tensor network object representing a ket circuit.
             loglevel: Logger verbosity level.
+            logfile: If provided, log is written to this file rather than stream.
         """
-        self._logger = set_logger("PauliOperatorTensorNetwork", loglevel)
+        self._logger = set_logger("PauliOperatorTensorNetwork", level=loglevel, file=logfile)
         self._pauli_tensors = [self.PAULI[pauli.name] for pauli in paulis.map.values()]
         self._logger.debug(f"Pauli tensors: {self._pauli_tensors}")
         qubits = [q for q in paulis.map.keys()]

--- a/pytket/extensions/cutensornet/general_state/tensor_network_convert.py
+++ b/pytket/extensions/cutensornet/general_state/tensor_network_convert.py
@@ -43,7 +43,11 @@ class TensorNetwork:
     """Responsible for converting pytket circuit to a tensor network and handling it."""
 
     def __init__(
-        self, circuit: Circuit, adj: bool = False, loglevel: int = logging.INFO, logfile: Optional[str] = None
+        self,
+        circuit: Circuit,
+        adj: bool = False,
+        loglevel: int = logging.INFO,
+        logfile: Optional[str] = None,
     ) -> None:
         """Constructs a tensor network from a pytket circuit.
 
@@ -574,7 +578,9 @@ class PauliOperatorTensorNetwork:
             loglevel: Logger verbosity level.
             logfile: If provided, log is written to this file rather than stream.
         """
-        self._logger = set_logger("PauliOperatorTensorNetwork", level=loglevel, file=logfile)
+        self._logger = set_logger(
+            "PauliOperatorTensorNetwork", level=loglevel, file=logfile
+        )
         self._pauli_tensors = [self.PAULI[pauli.name] for pauli in paulis.map.values()]
         self._logger.debug(f"Pauli tensors: {self._pauli_tensors}")
         qubits = [q for q in paulis.map.keys()]

--- a/pytket/extensions/cutensornet/general_state/tensor_network_state.py
+++ b/pytket/extensions/cutensornet/general_state/tensor_network_state.py
@@ -57,6 +57,7 @@ class GeneralState:
             scratch space; value between 0 and 1. Defaults to ``0.8``.
         loglevel: Internal logger output level. Use 30 for warnings only, 20 for
             verbose and 10 for debug mode.
+        logfile: If provided, log is written to this file rather than stream.
     """
 
     def __init__(
@@ -65,8 +66,9 @@ class GeneralState:
         attributes: Optional[dict] = None,
         scratch_fraction: float = 0.8,
         loglevel: int = logging.WARNING,
+        logfile: Optional[str] = None,
     ) -> None:
-        self._logger = set_logger("GeneralState", loglevel)
+        self._logger = set_logger("GeneralState", level=loglevel, file=logfile)
 
         # Remove end-of-circuit measurements and keep track of them separately
         # It also resolves implicit swaps
@@ -348,6 +350,7 @@ class GeneralBraOpKet:
             scratch space; value between 0 and 1. Defaults to ``0.8``.
         loglevel: Internal logger output level. Use 30 for warnings only, 20 for
             verbose and 10 for debug mode.
+        logfile: If provided, log is written to this file rather than stream.
 
     Raises:
         ValueError: If the circuits for ``ket`` or ``bra`` contain measurements.
@@ -361,8 +364,9 @@ class GeneralBraOpKet:
         attributes: Optional[dict] = None,
         scratch_fraction: float = 0.8,
         loglevel: int = logging.WARNING,
+        logfile: Optional[str] = None,
     ) -> None:
-        self._logger = set_logger("GeneralBraOpKet", loglevel)
+        self._logger = set_logger("GeneralBraOpKet", level=loglevel, file=logfile)
 
         # Check that the circuits have the same qubits
         if set(ket.qubits) != set(bra.qubits):

--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -58,6 +58,7 @@ class Config:
         k: int = 4,
         optim_delta: float = 1e-5,
         loglevel: int = logging.WARNING,
+        logfile: Optional[str] = None,
     ):
         """Instantiate a configuration object for ``StructuredState`` simulation.
 
@@ -101,6 +102,7 @@ class Config:
                 Default value is ``1e-5``.
             loglevel: Internal logger output level. Use 30 for warnings only, 20 for
                 verbose and 10 for debug mode.
+            logfile: If provided, log will be written to the given file.
 
         Raises:
             ValueError: If both ``chi`` and ``truncation_fidelity`` are fixed.
@@ -160,6 +162,7 @@ class Config:
         self.k = k
         self.optim_delta = 1e-5
         self.loglevel = loglevel
+        self.logfile = logfile
 
     def copy(self) -> Config:
         """Standard copy of the contents."""

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -92,7 +92,7 @@ class MPS(StructuredState):
         """
         self._lib = libhandle
         self._cfg = config
-        self._logger = set_logger("MPS", level=config.loglevel)
+        self._logger = set_logger("MPS", level=config.loglevel, file=config.logfile)
         self._rng = Random()
         self._rng.seed(self._cfg.seed)
         self.fidelity = 1.0

--- a/pytket/extensions/cutensornet/structured_state/simulation.py
+++ b/pytket/extensions/cutensornet/structured_state/simulation.py
@@ -81,7 +81,7 @@ def simulate(
         An instance of ``StructuredState`` for (an approximation of) the final state
         of the circuit. The instance be of the class matching ``algorithm``.
     """
-    logger = set_logger("Simulation", level=config.loglevel)
+    logger = set_logger("Simulation", level=config.loglevel, file=config.logfile)
 
     if compilation_params is None:
         compilation_params = dict()
@@ -132,6 +132,8 @@ def simulate(
 
     # Run the simulation
     logger.info("Running simulation...")
+    logger.info(f"Using {algorithm}")
+    logger.info(vars(config))
     # Apply the gates
     for i, g in enumerate(commands):
         state.apply_gate(g)

--- a/pytket/extensions/cutensornet/structured_state/ttn.py
+++ b/pytket/extensions/cutensornet/structured_state/ttn.py
@@ -128,7 +128,7 @@ class TTN(StructuredState):
         """
         self._lib = libhandle
         self._cfg = config
-        self._logger = set_logger("TTN", level=config.loglevel)
+        self._logger = set_logger("TTN", level=config.loglevel, file=config.logfile)
         self._rng = Random()
         self._rng.seed(self._cfg.seed)
 


### PR DESCRIPTION
# Description

Allow users to specify file to write log on.

This was a handy addition to make my life easier when organising files for the benchmarking challenge.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
