### PR TITLE
[bug] `apply_unitary` ignores `kill_threshold`

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.11.0"
+__extension_version__ = "0.11.1"
 __extension_name__ = "pytket-cutensornet"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,9 +3,10 @@
 Changelog
 ~~~~~~~~~
 
-0.12.0 (unreleased)
+0.11.1 (March 2025)
 -------------------
 
+* Bug fix: ``kill_threshold`` no longer ignored when using ``apply_unitary``.
 * Update pytket minimium version requirement to 2.0.1.
 
 0.11.0 (March 2025)

--- a/pytket/extensions/cutensornet/structured_state/general.py
+++ b/pytket/extensions/cutensornet/structured_state/general.py
@@ -222,12 +222,6 @@ class StructuredState(ABC):
         self._logger.debug(f"Applying {gate}.")
         self._apply_command(gate.op, gate.qubits, gate.bits, gate.args)
 
-        if self.fidelity < self._cfg.kill_threshold:
-            raise LowFidelityException(
-                f"Fidelity estimate ({self.fidelity}) dropped below the "
-                f"kill_threshold set by the user ({self._cfg.kill_threshold})."
-            )
-
         return self
 
     def _apply_command(

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -35,7 +35,7 @@ from pytket.pauli import Pauli, QubitPauliString
 
 from pytket.extensions.cutensornet.general import CuTensorNetHandle, set_logger
 
-from .general import Config, StructuredState, Tensor
+from .general import Config, StructuredState, Tensor, LowFidelityException
 
 
 class DirMPS(Enum):
@@ -213,6 +213,12 @@ class MPS(StructuredState):
 
         else:
             raise ValueError("Gates must act on only 1 or 2 qubits!")
+
+        if self.fidelity < self._cfg.kill_threshold:
+            raise LowFidelityException(
+                f"Fidelity estimate ({self.fidelity}) dropped below the "
+                f"kill_threshold set by the user ({self._cfg.kill_threshold})."
+            )
 
         return self
 

--- a/pytket/extensions/cutensornet/structured_state/ttn.py
+++ b/pytket/extensions/cutensornet/structured_state/ttn.py
@@ -36,7 +36,7 @@ from pytket.pauli import QubitPauliString
 
 from pytket.extensions.cutensornet.general import CuTensorNetHandle, set_logger
 
-from .general import Config, StructuredState, Tensor
+from .general import Config, StructuredState, Tensor, LowFidelityException
 
 
 class DirTTN(IntEnum):
@@ -295,6 +295,12 @@ class TTN(StructuredState):
 
         else:
             raise ValueError("Gates must act on only 1 or 2 qubits!")
+
+        if self.fidelity < self._cfg.kill_threshold:
+            raise LowFidelityException(
+                f"Fidelity estimate ({self.fidelity}) dropped below the "
+                f"kill_threshold set by the user ({self._cfg.kill_threshold})."
+            )
 
         return self
 


### PR DESCRIPTION
# Description

When testing on `qemulator`, which uses `apply_unitary`, I realised that `kill_threshold` was being ignored. This PR fixes it.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
