### PR TITLE
Add docs coverage and warning checks to CI and resolve failures for both

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,17 +69,13 @@ jobs:
         path: wheelhouse/
     - name: install poetry
       run: pip install poetry
-    - name: Install docs dependencies
-      if: (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
-      run: |
-        cd docs
-        bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry run pip install $w ; done
     - name: Build docs
       if: (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20
       run: |
         cd docs
+        bash ./install.sh
+        poetry run pip install ../.
         poetry run bash ./build-docs.sh
 
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-        submodules: true
+        submodules: recursive
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       uses: actions/setup-python@v5

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -13,7 +13,9 @@ EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 
 # Build the docs. Ensure we have the correct project title.
-sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
+sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
+
+sphinx-build -W -v -b coverage . build/coverage || exit 1
 
 # Remove copied files. This ensures reusability.
 rm -r _static 

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -9,9 +9,6 @@ cp pytket-docs-theming/conf.py .
 # Get the name of the project
 EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 
-# Correct github link in navbar
-sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
-
 # Build the docs. Ensure we have the correct project title.
 sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,9 +11,9 @@ a high-performance library aimed at quantum circuit simulations on the NVIDIA GP
 
 We provide two core functionalities:
 
-* *Exact value calculation*: use ``GeneralState`` and ``GenearlBraOpKet`` to translate a ``pytket`` into a tensor network and obtain amplitudes and expectation values via full tensor network contraction using ``cuQuantum``'s optimised contraction path.
+* *Exact value calculation*: use :py:class:`~.GeneralState` and :py:class:`~.GeneralBraOpKet` to translate a ``pytket`` into a tensor network and obtain amplitudes and expectation values via full tensor network contraction using ``cuQuantum``'s optimised contraction path.
 
-* *Approximate state evolution*: use ``simulate`` to simulate a ``pytket`` circuit, returning a tensor network representation of the approximate output state, from which you can query properties, such as amplitudes and expectation values.
+* *Approximate state evolution*: use :py:func:`~.simulate` to simulate a ``pytket`` circuit, returning a tensor network representation of the approximate output state, from which you can query properties, such as amplitudes and expectation values.
 
 
 ``pytket-cutensornet`` is available for Python 3.10, 3.11 and 3.12 on Linux.

--- a/docs/modules/general_state.rst
+++ b/docs/modules/general_state.rst
@@ -2,8 +2,9 @@ General state (exact) simulation
 ================================
 
 .. automodule:: pytket.extensions.cutensornet.general_state
+.. automodule:: pytket.extensions.cutensornet.general_state.tensor_network_state
 
-.. autoclass:: pytket.extensions.cutensornet.general_state.GeneralState()
+.. autoclass:: pytket.extensions.cutensornet.general_state.tensor_network_state.GeneralState()
 
     .. automethod:: sample
     .. automethod:: get_amplitude
@@ -11,7 +12,7 @@ General state (exact) simulation
     .. automethod:: expectation_value
     .. automethod:: destroy
 
-.. autoclass:: pytket.extensions.cutensornet.general_state.GeneralBraOpKet()
+.. autoclass:: pytket.extensions.cutensornet.general_state.tensor_network_state.GeneralBraOpKet()
 
     .. automethod:: contract
     .. automethod:: destroy
@@ -20,4 +21,36 @@ Pytket backend
 ~~~~~~~~~~~~~~
 
 .. automodule:: pytket.extensions.cutensornet
-    :members: CuTensorNetStateBackend, CuTensorNetShotsBackend
+.. automodule:: pytket.extensions.cutensornet.backends
+.. automodule:: pytket.extensions.cutensornet.backends.cutensornet_backend
+
+    .. autoclass:: CuTensorNetStateBackend
+        :members:
+    
+    .. autoclass:: CuTensorNetShotsBackend
+        :members:
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+.. automodule:: pytket.extensions.cutensornet.general_state.tensor_network_convert
+
+    .. autofunction:: get_circuit_overlap
+    .. autofunction:: get_operator_expectation_value
+    .. autofunction:: measure_qubit_state
+    .. autofunction:: measure_qubits_state
+    .. autofunction:: tk_to_tensor_network
+    
+    .. autoclass:: TensorNetwork
+        :members:
+    
+    .. autoclass:: ExpectationValueTensorNetwork
+        :members:
+    
+    .. autoclass:: PauliOperatorTensorNetwork
+        :members:
+
+.. automodule:: pytket.extensions.cutensornet.general_state.utils
+
+    .. autofunction:: circuit_statevector_postselect
+    .. autofunction:: statevector_postselect

--- a/docs/modules/structured_state.rst
+++ b/docs/modules/structured_state.rst
@@ -6,31 +6,39 @@ Structured state evolution
 Library handle
 ~~~~~~~~~~~~~~
 
-.. autoclass:: pytket.extensions.cutensornet.CuTensorNetHandle
+.. automodule:: pytket.extensions.cutensornet.general
 
-    .. automethod:: destroy
+    .. autofunction:: set_logger
+    
+    .. autoclass:: CuTensorNetHandle
+        :members:
 
 
 Simulation
 ~~~~~~~~~~
 
-.. autofunction:: pytket.extensions.cutensornet.structured_state.simulate
+.. automodule:: pytket.extensions.cutensornet.structured_state.simulation
+.. autofunction:: pytket.extensions.cutensornet.structured_state.simulation.simulate
 
 .. autoenum:: pytket.extensions.cutensornet.structured_state.SimulationAlgorithm()
     :members:
 
-.. autoclass:: pytket.extensions.cutensornet.structured_state.Config()
+.. automodule:: pytket.extensions.cutensornet.structured_state.general
+.. autoclass:: pytket.extensions.cutensornet.structured_state.general.Config()
 
     .. automethod:: __init__
+    .. automethod:: copy
 
 
 Classes
 ~~~~~~~
 
-.. autoclass:: pytket.extensions.cutensornet.structured_state.StructuredState()
+.. autoclass:: pytket.extensions.cutensornet.structured_state.general.StructuredState()
 
     .. automethod:: is_valid
     .. automethod:: apply_gate
+    .. automethod:: apply_cnx
+    .. automethod:: apply_pauli_gadget
     .. automethod:: apply_unitary
     .. automethod:: apply_scalar
     .. automethod:: apply_qubit_relabelling
@@ -49,23 +57,55 @@ Classes
     .. automethod:: update_libhandle
     .. automethod:: copy
 
+.. automodule:: pytket.extensions.cutensornet.structured_state.mps
+.. autoclass:: pytket.extensions.cutensornet.structured_state.mps.MPS
+    :members:
+
+.. autoclass:: pytket.extensions.cutensornet.structured_state.DirMPS
+    :members:
+
+.. automodule:: pytket.extensions.cutensornet.structured_state.ttn_gate
 .. autoclass:: pytket.extensions.cutensornet.structured_state.TTNxGate()
 
     .. automethod:: __init__
 
-.. autoclass:: pytket.extensions.cutensornet.structured_state.MPSxGate()
+.. automodule:: pytket.extensions.cutensornet.structured_state.mps_gate
+.. autoclass:: pytket.extensions.cutensornet.structured_state.mps_gate.MPSxGate()
 
     .. automethod:: __init__
     .. automethod:: add_qubit
     .. automethod:: get_entanglement_entropy
+    .. automethod:: apply_cnx
+    .. automethod:: apply_pauli_gadget
+    .. automethod:: measure_pauli_string
 
-.. autoclass:: pytket.extensions.cutensornet.structured_state.MPSxMPO()
+.. automodule:: pytket.extensions.cutensornet.structured_state.mps_mpo
+.. autoclass:: pytket.extensions.cutensornet.structured_state.mps_mpo.MPSxMPO()
 
     .. automethod:: __init__
+    .. automethod:: add_qubit
+    .. automethod:: apply_qubit_relabelling
+    .. automethod:: get_physical_dimension
+    .. automethod:: update_libhandle
 
+.. automodule:: pytket.extensions.cutensornet.structured_state.ttn
+.. autoclass:: pytket.extensions.cutensornet.structured_state.ttn.TTN
+    :members:
+
+.. autoclass:: pytket.extensions.cutensornet.structured_state.ttn.DirTTN
+    :members:
+
+.. autoclass:: pytket.extensions.cutensornet.structured_state.ttn.TreeNode
+    
+    .. automethod:: copy
 
 Miscellaneous
 ~~~~~~~~~~~~~
 
-.. autofunction:: pytket.extensions.cutensornet.structured_state.prepare_circuit_mps
-.. autoclass:: pytket.extensions.cutensornet.structured_state.LowFidelityException
+.. autofunction:: pytket.extensions.cutensornet.structured_state.simulation.prepare_circuit_mps
+.. automodule:: pytket.extensions.cutensornet.structured_state.classical
+.. autofunction:: pytket.extensions.cutensornet.structured_state.classical.apply_classical_command
+.. autofunction:: pytket.extensions.cutensornet.structured_state.classical.evaluate_clexpr
+.. autofunction:: pytket.extensions.cutensornet.structured_state.classical.from_little_endian
+.. autoexception:: pytket.extensions.cutensornet.structured_state.LowFidelityException
+.. automodule:: pytket.extensions.cutensornet._metadata

--- a/pytket/extensions/cutensornet/__init__.py
+++ b/pytket/extensions/cutensornet/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Module for conversion from tket primitives to cuQuantum primitives."""
 
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_name__, __extension_version__  # type: ignore

--- a/pytket/extensions/cutensornet/backends/__init__.py
+++ b/pytket/extensions/cutensornet/backends/__init__.py
@@ -11,6 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Backend for utilising the cuQuantum simulator directly from pytket"""
 
 from .cutensornet_backend import CuTensorNetShotsBackend, CuTensorNetStateBackend

--- a/pytket/extensions/cutensornet/backends/cutensornet_backend.py
+++ b/pytket/extensions/cutensornet/backends/cutensornet_backend.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Methods to allow tket circuits to be run on the cuTensorNet simulator."""
-
 from abc import abstractmethod
 from collections.abc import Sequence
 from uuid import uuid4
@@ -48,7 +46,7 @@ from .._metadata import __extension_name__, __extension_version__
 
 
 class _CuTensorNetBaseBackend(Backend):
-    """A pytket Backend wrapping around the ``GeneralState`` simulator."""
+    """A pytket :py:class:`~pytket.backends.backend.Backend` wrapping around the :py:class:`~.GeneralState` simulator."""
 
     _persistent_handles = False
 
@@ -81,7 +79,7 @@ class _CuTensorNetBaseBackend(Backend):
 
     def rebase_pass(self) -> BasePass:
         """This method returns a dummy pass that does nothing, since there is
-        no need to rebase. It is provided by requirement of a child of Backend,
+        no need to rebase. It is provided by requirement of a child of :py:class:`~pytket.backends.backend.Backend`,
         but it should not be included in the documentation.
         """
         return CustomPass(lambda circ: circ)  # Do nothing
@@ -121,7 +119,7 @@ class _CuTensorNetBaseBackend(Backend):
         """Returns circuit status object.
 
         Returns:
-            CircuitStatus object.
+            :py:class:`~pytket.backends.status.CircuitStatus` object.
 
         Raises:
             CircuitNotRunError: if there is no handle object in cache.
@@ -158,7 +156,7 @@ class _CuTensorNetBaseBackend(Backend):
 
 
 class CuTensorNetStateBackend(_CuTensorNetBaseBackend):
-    """A pytket Backend using ``GeneralState`` to obtain state vectors."""
+    """A pytket :py:class:`~pytket.backends.backend.Backend` using :py:class:`~.GeneralState` to obtain state vectors."""
 
     _supports_state = True
 
@@ -233,7 +231,7 @@ class CuTensorNetStateBackend(_CuTensorNetBaseBackend):
 
 
 class CuTensorNetShotsBackend(_CuTensorNetBaseBackend):
-    """A pytket Backend using ``GeneralState`` to obtain shots."""
+    """A pytket :py:class:`~pytket.backends.backend.Backend` using :py:class:`~.GeneralState` to obtain shots."""
 
     _supports_shots = True
     _supports_counts = True
@@ -282,7 +280,7 @@ class CuTensorNetShotsBackend(_CuTensorNetBaseBackend):
                 Optionally, this can be a list of shots specifying the number of shots
                 for each circuit separately.
             valid_check: Whether to check for circuit correctness.
-            seed: An optional RNG seed. Different calls to ``process_circuits`` with the
+            seed: An optional RNG seed. Different calls to :py:meth:`~.process_circuits` with the
                 same seed will generate the same list of shot outcomes.
             tnconfig: Optional. A dict of cuTensorNet ``TNConfig`` keys and
                 their values.

--- a/pytket/extensions/cutensornet/general_state/__init__.py
+++ b/pytket/extensions/cutensornet/general_state/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Module for simulating circuits with no predetermined tensor network structure."""
 
 from .tensor_network_convert import (
     ExpectationValueTensorNetwork,

--- a/pytket/extensions/cutensornet/general_state/tensor_network_state.py
+++ b/pytket/extensions/cutensornet/general_state/tensor_network_state.py
@@ -347,8 +347,8 @@ class GeneralBraOpKet:
         The operator is provided when ``contract`` is called.
 
     Args:
-        bra: A pytket circuit describing the |bra> state.
-        ket: A pytket circuit describing the |ket> state.
+        bra: A pytket circuit describing the ``|bra>`` state.
+        ket: A pytket circuit describing the ``|ket>`` state.
         attributes: Optional. A dict of cuTensorNet ``TNConfig`` keys and
             their values.
         scratch_fraction: Optional. Fraction of free memory on GPU to allocate as

--- a/pytket/extensions/cutensornet/general_state/tensor_network_state.py
+++ b/pytket/extensions/cutensornet/general_state/tensor_network_state.py
@@ -53,7 +53,7 @@ class GeneralState:
         Preferably used as ``with GeneralState(...) as state:`` so that GPU memory is
         automatically released after execution.
 
-        The ``circuit`` must not contain any ``CircBox`` or non-unitary command.
+        The ``circuit`` must not contain any :py:class:`~pytket.circuit.CircBox` or non-unitary command.
 
     Args:
         circuit: A pytket circuit to be converted into a tensor network.
@@ -148,8 +148,7 @@ class GeneralState:
         """Contracts the circuit and returns the final statevector.
 
         Args:
-            symbol_map: A dictionary where each element of the pytket circuit's
-                ``.free_symbols()`` is assigned a real number.
+            symbol_map: A dictionary where each element of :py:meth`pytket._tket.circuit.Circuit.free_symbols` is assigned a real number.
             on_host: Optional. If ``True``, converts cupy ``ndarray`` to numpy
                 ``ndarray``, copying it to host device (CPU). Defaults to ``True``.
         Returns:
@@ -185,8 +184,7 @@ class GeneralState:
         Args:
             state: The integer whose bitstring describes the computational state.
                 The qubits in the bitstring are in increasing lexicographic order.
-            symbol_map: A dictionary where each element of the pytket circuit's
-                ``.free_symbols()`` is assigned a real number.
+            symbol_map: A dictionary where each element of :py:meth:`pytket._tket.circuit.Circuit.free_symbols` is assigned a real number.
 
         Returns:
             The amplitude of the computational state in ``self``.
@@ -213,8 +211,7 @@ class GeneralState:
 
         Args:
             operator: The operator whose expectation value is to be calculated.
-            symbol_map: A dictionary where each element of the pytket circuit's
-                ``.free_symbols()`` is assigned a real number.
+            symbol_map: A dictionary where each element of :py:meth:`pytket._tket.circuit.Circuit.free_symbols` is assigned a real number.
 
         Returns:
             The expectation value.
@@ -258,13 +255,12 @@ class GeneralState:
 
         Args:
             n_shots: The number of samples to obtain.
-            symbol_map: A dictionary where each element of the pytket circuit's
-                ``.free_symbols()`` is assigned a real number.
-            seed: An optional RNG seed. Different calls to ``sample`` with the same
+            symbol_map: A dictionary where each element of :py:meth:`pytket._tket.circuit.Circuit.free_symbols` is assigned a real number.
+            seed: An optional RNG seed. Different calls to :py:meth:`~.sample` with the same
                 seed will generate the same list of shot outcomes.
 
         Returns:
-            A pytket ``BackendResult`` with the data from the shots.
+            A :py:class:`~pytket.backends.backendresult.BackendResult` with the data from the shots.
 
         Raises:
             ValueError: If the circuit contains no measurements.
@@ -320,7 +316,7 @@ class GeneralState:
 
         The preferred approach is to use a context manager as in
         ``with GeneralState(...) as state:``. Otherwise, the user must release
-        memory explicitly by calling ``destroy()``.
+        memory explicitly by calling :py:meth:`destroy`.
         """
         self._logger.debug("Freeing memory of GeneralState")
         self.tn_state.free()
@@ -342,9 +338,9 @@ class GeneralBraOpKet:
         Preferably used as ``with GeneralBraOpKet(...) as braket:`` so that GPU memory
         is automatically released after execution.
 
-        The circuits must not contain any ``CircBox`` or non-unitary command.
+        The circuits must not contain any :py:class:`~pytket.circuit.CircBox` or non-unitary command.
 
-        The operator is provided when ``contract`` is called.
+        The operator is provided when :py:meth:`~.contract` is called.
 
     Args:
         bra: A pytket circuit describing the ``|bra>`` state.
@@ -512,10 +508,10 @@ class GeneralBraOpKet:
         """Contract the tensor network to obtain the value of ``<bra|operator|ket>``.
 
         Args:
-            operator: A pytket ``QubitPauliOperator`` describing the operator. If not
+            operator: A :py:class:`pytket.utils.operators.QubitPauliOperator` describing the operator. If not
                 given, then the identity operator is used, so it computes inner product.
             symbol_map: A dictionary where each element of both pytket circuits'
-                ``.free_symbols()`` is assigned a real number.
+                :py:meth:`~pytket._tket.circuit.Circuit.free_symbols` is assigned a real number.
 
         Returns:
             The value of ``<bra|operator|ket>``.
@@ -586,7 +582,7 @@ class GeneralBraOpKet:
 
         The preferred approach is to use a context manager as in
         ``with GeneralBraOpKet(...) as braket:``. Otherwise, the user must release
-        memory explicitly by calling ``destroy()``.
+        memory explicitly by calling :py:meth:`~.destroy`.
         """
         self._logger.debug("Freeing memory of GeneralBraOpKet")
         self.tn.free()
@@ -608,7 +604,7 @@ def _formatted_tensor(matrix: NDArray, n_qubits: int) -> cp.ndarray:
 
 
 def _remove_meas_and_implicit_swaps(circ: Circuit) -> tuple[Circuit, dict[Qubit, Bit]]:
-    """Convert a pytket Circuit to an equivalent circuit with no measurements or
+    """Convert a pytket :py:class:`~pytket._tket.circuit.Circuit` to an equivalent circuit with no measurements or
     implicit swaps. The measurements are returned as a map between qubits and bits.
 
     Only supports end-of-circuit measurements, which are removed from the returned

--- a/pytket/extensions/cutensornet/general_state/utils.py
+++ b/pytket/extensions/cutensornet/general_state/utils.py
@@ -92,7 +92,7 @@ def circuit_statevector_postselect(
 ) -> NDArray:
     """Post selects a circuit statevector. recursively calls
     itself if there are multiple post select qubits. Should only be
-    used for testing small circuits as it uses the circuit.get_unitary() method.
+    used for testing small circuits as it uses the :py:meth:`pytket._tket.circuit.Circuit.get_unitary` method.
 
     Args:
         circ: Circuit.

--- a/pytket/extensions/cutensornet/structured_state/mps.py
+++ b/pytket/extensions/cutensornet/structured_state/mps.py
@@ -53,7 +53,7 @@ class MPS(StructuredState):
     """Represents a state as a Matrix Product State.
 
     Attributes:
-        tensors (list[Tensor]): A list of tensors in the MPS; ``tensors[0]`` is
+        tensors (list[Any]): A list of tensors in the MPS; ``tensors[0]`` is
             the leftmost and ``tensors[len(self)-1]`` is the rightmost; ``tensors[i]``
             and ``tensors[i+1]`` are connected in the MPS via a bond. All of the
             tensors are rank three, with the dimensions listed in ``.shape`` matching
@@ -61,7 +61,7 @@ class MPS(StructuredState):
         canonical_form (dict[int, Optional[DirMPS]]): A dictionary mapping
             positions to the canonical form direction of the corresponding tensor,
             or ``None`` if it the tensor is not canonicalised.
-        qubit_position (dict[pytket.circuit.Qubit, int]): A dictionary mapping circuit
+        qubit_position (dict[pytket._tket.unit_id.Qubit, int]): A dictionary mapping circuit
             qubits to the position its tensor is at in the MPS.
         fidelity (float): A lower bound of the fidelity, obtained by multiplying
             the fidelities after each contraction. The fidelity of a contraction

--- a/pytket/extensions/cutensornet/structured_state/ttn.py
+++ b/pytket/extensions/cutensornet/structured_state/ttn.py
@@ -80,9 +80,9 @@ class TTN(StructuredState):
     """Represents a state as a Tree Tensor Network.
 
     Attributes:
-        nodes (dict[RootPath, TreeNode]): A dictionary providing the tree node
+        nodes (dict[tuple[DirTTN, ...], TreeNode]): A dictionary providing the tree node
             of the given root path in the TTN.
-        qubit_position (dict[pytket.circuit.Qubit, tuple[RootPath, int]]): A dictionary
+        qubit_position (dict[pytket._tket.unit_id.Qubit, tuple[tuple[DirTTN, ...], int]]): A dictionary
             mapping circuit qubits to their address in the TTN.
         fidelity (float): A lower bound of the fidelity, obtained by multiplying
             the fidelities after each contraction. The fidelity of a contraction


### PR DESCRIPTION
# Description

Adding CI checks for documentation coverage (making sure that every publicly visible method and class - those whose names don't begin with an underscore - is included in the docs) and enforcing sphinx nitpicky to report any formatting failures and broken cross-references.

This PR also resolves existing gaps in coverage and broken formatting. Some of the newly documented content required for docs coverage may have been intended to be internal components required only as part of the conversion or infrastructure code and is not intended for end users; I will need some help spotting any such instances so we can underscore them out to clarify this intention.

# Related issues

This works towards https://github.com/CQCL/tket/issues/1857, following on from https://github.com/CQCL/tket/pull/1910 for the core package and related PRs for other extensions.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
